### PR TITLE
Fix indentation in agent modules

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -7,41 +7,39 @@ from .template_matcher import TemplateMatcher
 
 
 class ChannelSwitcher:
-"""
-Kliknięcie CH1..CH8 na minimapie w prawym górnym rogu.
-Wymaga szablonów: assets/templates/ch1.png ... ch8.png
-"""
-def __init__(self, win: WindowCapture, templates_dir="assets/templates", dry: bool=False):
-self.win = win
-self.tm = TemplateMatcher(templates_dir)
-self.dry = dry
+    """
+    Kliknięcie CH1..CH8 na minimapie w prawym górnym rogu.
+    Wymaga szablonów: assets/templates/ch1.png ... ch8.png
+    """
 
+    def __init__(self, win: WindowCapture, templates_dir: str = "assets/templates", dry: bool = False):
+        self.win = win
+        self.tm = TemplateMatcher(templates_dir)
+        self.dry = dry
 
-def _frame(self):
-fr = self.win.grab()
-return np.array(fr)[:, :, :3].copy()
+    def _frame(self) -> np.ndarray:
+        fr = self.win.grab()
+        return np.array(fr)[:, :, :3].copy()
 
+    def switch(self, ch: int, thresh: float = 0.82, tries: int = 3) -> bool:
+        if not (1 <= ch <= 8):
+            raise ValueError("Kanał poza zakresem 1..8")
+        # ROI: obszar minimapy ~ prawy górny róg okna
+        _, _, w, h = self.win.region
+        roi = (max(0, w - 260), 20, 240, 240)
+        name = f"ch{ch}"
 
-def switch(self, ch: int, thresh=0.82, tries=3):
-if not (1 <= ch <= 8):
-raise ValueError("Kanał poza zakresem 1..8")
-# ROI: obszar minimapy ~ prawy górny róg okna
-_, _, w, h = self.win.region
-roi = (max(0, w - 260), 20, 240, 240)
-name = f"ch{ch}"
-
-
-for _ in range(tries):
-frame = self._frame()
-m = self.tm.find(frame, name, thresh=thresh, roi=roi, multi_scale=True)
-if m:
-L, T, _, _ = self.win.region
-cx, cy = m["center"]
-self.win.focus()
-if not self.dry:
-pyautogui.moveTo(L + cx, T + cy, duration=0.05)
-pyautogui.click()
-time.sleep(0.3)
-return True
-time.sleep(0.2)
-return False
+        for _ in range(tries):
+            frame = self._frame()
+            m = self.tm.find(frame, name, thresh=thresh, roi=roi, multi_scale=True)
+            if m:
+                L, T, _, _ = self.win.region
+                cx, cy = m["center"]
+                self.win.focus()
+                if not self.dry:
+                    pyautogui.moveTo(L + cx, T + cy, duration=0.05)
+                    pyautogui.click()
+                time.sleep(0.3)
+                return True
+            time.sleep(0.2)
+        return False

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
-import time
-import numpy as np
 
+import numpy as np
 
 from recorder.window_capture import WindowCapture
 from agent.teleport import Teleporter
@@ -12,59 +11,52 @@ from agent.wasd import KeyHold
 
 
 class CycleFarm:
-"""
-Cykl 8×8: sloty 1..8 × CH(ch_from..ch_to).
-Na każdym slocie: teleport -> poluj (z autoskanem 'E').
-Brak celu -> krótki skan E; nadal brak -> kolejny slot.
-Ma cooldown slotów (minuty) by nie wracać od razu.
-"""
+    """
+    Cykl 8×8: sloty 1..8 × CH(ch_from..ch_to).
+    Na każdym slocie: teleport -> poluj (z autoskanem 'E').
+    Brak celu -> krótki skan E; nadal brak -> kolejny slot.
+    Ma cooldown slotów (minuty) by nie wracać od razu.
+    """
 
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.win = WindowCapture(cfg["window"]["title_substr"])
+        assert self.win.locate()
 
-def __init__(self, cfg: dict):
-self.cfg = cfg
-self.win = WindowCapture(cfg["window"]["title_substr"])
-assert self.win.locate()
+        self.dry = cfg.get("dry_run", False)
+        self.tp = Teleporter(self.win, use_ocr=True, dry=self.dry)
+        self.ch = ChannelSwitcher(self.win, dry=self.dry)
+        self.agent = HuntDestroy(cfg, self.win)
+        self.det = ObjectDetector(cfg["detector"]["model_path"], cfg["detector"]["classes"])
+        self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
+        self._stop = False
 
+        # progi i priorytety
+        self.conf_thr = float(cfg.get("detector", {}).get("conf_thr", 0.5))
+        self.priority = list(cfg.get("priority", []))
 
-self.dry = cfg.get("dry_run", False)
-self.tp = Teleporter(self.win, use_ocr=True, dry=self.dry)
-self.ch = ChannelSwitcher(self.win, dry=self.dry)
-self.agent = HuntDestroy(cfg, self.win)
-self.det = ObjectDetector(cfg["detector"]["model_path"], cfg["detector"]["classes"])
-self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, 'is_foreground', None))
-self._stop = False
+        # parametry skanowania
+        scan = cfg.get("scan", {})
+        self.spin_key = scan.get("key", "e")
+        self.sweep_ms = int(scan.get("sweep_ms", 250))
+        self.sweeps = int(scan.get("sweeps", 8))
+        self.idle_before_scan = float(scan.get("idle_sec", 1.5))
+        self.pause_between_sweeps = float(scan.get("pause", 0.12))
 
+        # cooldown slotów
+        self.cooldown = {}
+        self.cooldown_min = int(cfg.get("cooldowns", {}).get("slot_min", 10))
 
-# progi i priorytety
-self.conf_thr = float(cfg.get("detector", {}).get("conf_thr", 0.5))
-self.priority = list(cfg.get("priority", []))
+    def stop(self):
+        self._stop = True
+        try:
+            self.keys.stop()
+        except Exception:
+            pass
 
-
-# parametry skanowania
-scan = cfg.get("scan", {})
-self.spin_key = scan.get("key", "e")
-self.sweep_ms = int(scan.get("sweep_ms", 250))
-self.sweeps = int(scan.get("sweeps", 8))
-self.idle_before_scan = float(scan.get("idle_sec", 1.5))
-self.pause_between_sweeps = float(scan.get("pause", 0.12))
-
-
-# cooldown slotów
-self.cooldown = {}
-self.cooldown_min = int(cfg.get("cooldowns", {}).get("slot_min", 10))
-
-
-def stop(self):
-self._stop = True
-try:
-self.keys.stop()
-except Exception:
-pass
-
-
-# ---- detekcje ----
-def _any_target_seen(self) -> bool:
-fr = self.win.grab()
-frame = np.array(fr)[:, :, :3].copy()
-dets = self.det.infer(frame)
-self.stop()
+    # ---- detekcje ----
+    def _any_target_seen(self) -> bool:
+        fr = self.win.grab()
+        frame = np.array(fr)[:, :, :3].copy()
+        dets = self.det.infer(frame)
+        return bool(dets)

--- a/agent/detector.py
+++ b/agent/detector.py
@@ -1,38 +1,47 @@
 from __future__ import annotations
 from typing import List, Dict
+
 import numpy as np
 import cv2
 from ultralytics import YOLO
-
 
 # ogranicz wątki OpenCV na Windows (stabilniej na CPU)
 cv2.setNumThreads(1)
 
 
 class ObjectDetector:
-"""Lekka nakładka na Ultralytics YOLO do detekcji na klatce BGR (numpy array)."""
-def __init__(self, model_path: str, classes: list[str] | None = None, conf: float = 0.5, iou: float = 0.45, device=None):
-self.model_path = model_path
-self.model = YOLO(model_path)
-self.classes = classes
-self.conf = conf
-self.iou = iou
-self.device = device
+    """Lekka nakładka na Ultralytics YOLO do detekcji na klatce BGR (numpy array)."""
 
+    def __init__(self, model_path: str, classes: list[str] | None = None,
+                 conf: float = 0.5, iou: float = 0.45, device=None):
+        self.model_path = model_path
+        self.model = YOLO(model_path)
+        self.classes = classes
+        self.conf = conf
+        self.iou = iou
+        self.device = device
 
-def infer(self, frame_bgr: np.ndarray) -> List[Dict]:
-res = self.model.predict(source=frame_bgr, verbose=False, conf=self.conf, iou=self.iou, device=self.device)[0]
-out: List[Dict] = []
-names = res.names
-for box in res.boxes:
-cls_id = int(box.cls)
-name = names.get(cls_id, str(cls_id))
-if self.classes and name not in self.classes:
-continue
-x1, y1, x2, y2 = box.xyxy[0].cpu().numpy().tolist()
-out.append({
-'name': name,
-'bbox': [x1, y1, x2, y2],
-'conf': float(box.conf.cpu().numpy())
-})
-return out
+    def infer(self, frame_bgr: np.ndarray) -> List[Dict]:
+        res = self.model.predict(
+            source=frame_bgr,
+            verbose=False,
+            conf=self.conf,
+            iou=self.iou,
+            device=self.device,
+        )[0]
+        out: List[Dict] = []
+        names = res.names
+        for box in res.boxes:
+            cls_id = int(box.cls)
+            name = names.get(cls_id, str(cls_id))
+            if self.classes and name not in self.classes:
+                continue
+            x1, y1, x2, y2 = box.xyxy[0].cpu().numpy().tolist()
+            out.append(
+                {
+                    "name": name,
+                    "bbox": [x1, y1, x2, y2],
+                    "conf": float(box.conf.cpu().numpy()),
+                }
+            )
+        return out

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import time
 import numpy as np
 
-
 from .detector import ObjectDetector
 from .targets import pick_target
 from .avoid import CollisionAvoid
@@ -11,54 +10,54 @@ from .interaction import burst_click
 
 
 class HuntDestroy:
-def __init__(self, cfg, window_capture):
-self.win = window_capture
-self.det = ObjectDetector(cfg['detector']['model_path'], cfg['detector']['classes'], cfg['detector']['conf_thr'], cfg['detector']['iou_thr'])
-self.avoid = CollisionAvoid()
-# KeyHold z dry-run + watchdogiem fokusu
-self.keys = KeyHold(dry=cfg.get('dry_run', False), active_fn=getattr(self.win, 'is_foreground', None))
-self.desired_w = cfg['policy']['desired_box_w']
-self.deadzone = cfg['policy']['deadzone_x']
-self.priority = cfg.get('priority', ["boss", "metin", "potwory"]) # kolejność z GUI
-self.period = 1 / 15
+    def __init__(self, cfg, window_capture):
+        self.win = window_capture
+        self.det = ObjectDetector(
+            cfg["detector"]["model_path"],
+            cfg["detector"]["classes"],
+            cfg["detector"]["conf_thr"],
+            cfg["detector"]["iou_thr"],
+        )
+        self.avoid = CollisionAvoid()
+        # KeyHold z dry-run + watchdogiem fokusu
+        self.keys = KeyHold(dry=cfg.get("dry_run", False), active_fn=getattr(self.win, "is_foreground", None))
+        self.desired_w = cfg["policy"]["desired_box_w"]
+        self.deadzone = cfg["policy"]["deadzone_x"]
+        self.priority = cfg.get("priority", ["boss", "metin", "potwory"])  # kolejność z GUI
+        self.period = 1 / 15
 
+    def step(self):
+        fr = self.win.grab()
+        frame = np.array(fr)[:, :, :3].copy()
+        H, W = frame.shape[:2]
+        dets = self.det.infer(frame)
+        steer = self.avoid.steer(frame)
 
-def step(self):
-fr = self.win.grab(); frame = np.array(fr)[:, :, :3].copy()
-H, W = frame.shape[:2]
-dets = self.det.infer(frame)
-steer = self.avoid.steer(frame)
+        # sterowanie
+        self.keys.release_all()
+        if steer == "left":
+            self.keys.press("a")
+        elif steer == "right":
+            self.keys.press("d")
 
+        tgt = pick_target(dets, (W, H), priority_order=self.priority)
+        if tgt is None:
+            return
 
-# sterowanie
-self.keys.release_all()
-if steer == 'left':
-self.keys.press('a')
-elif steer == 'right':
-self.keys.press('d')
+        x1, y1, x2, y2 = tgt["bbox"]
+        cx = (x1 + x2) / 2 / W
+        bw = (x2 - x1) / W
 
+        if abs(cx - 0.5) > self.deadzone:
+            (self.keys.press("d") if cx > 0.5 else self.keys.press("a"))
+        if bw < self.desired_w * 0.95:
+            self.keys.press("w")
+        elif bw > self.desired_w * 1.25:
+            self.keys.press("s")
 
-tgt = pick_target(dets, (W, H), priority_order=self.priority)
-if tgt is None:
-return
-
-
-x1, y1, x2, y2 = tgt['bbox']
-cx = (x1 + x2) / 2 / W
-bw = (x2 - x1) / W
-
-
-if abs(cx - 0.5) > self.deadzone:
-(self.keys.press('d') if cx > 0.5 else self.keys.press('a'))
-if bw < self.desired_w * 0.95:
-self.keys.press('w')
-elif bw > self.desired_w * 1.25:
-self.keys.press('s')
-
-
-if bw >= self.desired_w * 0.9:
-left, top, w, h = self.win.region
-# w dry-run nie klikamy realnie – burst_click sam używa pyautogui
-if hasattr(self.keys, 'dry') and self.keys.dry:
-return
-burst_click((x1, y1, x2, y2), (left, top, w, h))
+        if bw >= self.desired_w * 0.9:
+            left, top, w, h = self.win.region
+            # w dry-run nie klikamy realnie – burst_click sam używa pyautogui
+            if hasattr(self.keys, "dry") and self.keys.dry:
+                return
+            burst_click((x1, y1, x2, y2), (left, top, w, h))

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -1,76 +1,74 @@
 from __future__ import annotations
+
 import time
 import numpy as np
 import pyautogui
 import easyocr
 
-
 from recorder.window_capture import WindowCapture
 from .template_matcher import TemplateMatcher
-
 
 pyautogui.PAUSE = 0.02
 
 
 class Teleporter:
-"""
-Panel teleportu:
-- open_panel(): Ctrl+X (z focusem)
-- go_page('Strona I'..'Strona VIII')
-- teleport(point, page)
-- teleport_slot(slot, page): scroll + retry, klik 'Wczytaj'
-Wymaga szablonów: wczytaj.png, strona_I.png..strona_VIII.png
-"""
-def __init__(self, win: WindowCapture, use_ocr=True, templates_dir="assets/templates", dry: bool=False):
-self.win = win
-self.tm = TemplateMatcher(templates_dir)
-self.reader = easyocr.Reader(['pl', 'en'], gpu=False) if use_ocr else None
-self.dry = dry
+    """
+    Panel teleportu:
+    - open_panel(): Ctrl+X (z focusem)
+    - go_page('Strona I'..'Strona VIII')
+    - teleport(point, page)
+    - teleport_slot(slot, page): scroll + retry, klik 'Wczytaj'
+    Wymaga szablonów: wczytaj.png, strona_I.png..strona_VIII.png
+    """
 
+    def __init__(self, win: WindowCapture, use_ocr: bool = True, templates_dir: str = "assets/templates", dry: bool = False):
+        self.win = win
+        self.tm = TemplateMatcher(templates_dir)
+        self.reader = easyocr.Reader(["pl", "en"], gpu=False) if use_ocr else None
+        self.dry = dry
 
-def _frame(self):
-fr = self.win.grab()
-return np.array(fr)[:, :, :3].copy()
+    def _frame(self) -> np.ndarray:
+        fr = self.win.grab()
+        return np.array(fr)[:, :, :3].copy()
 
+    def _safe_click(self, x: int, y: int) -> None:
+        if self.dry:
+            return
+        pyautogui.moveTo(x, y, duration=0.05)
+        pyautogui.click()
 
-def _safe_click(self, x, y):
-if self.dry:
-return
-pyautogui.moveTo(x, y, duration=0.05)
-pyautogui.click()
+    def open_panel(self) -> None:
+        self.win.focus()
+        if not self.dry:
+            pyautogui.hotkey("ctrl", "x")
+            time.sleep(0.35)
 
+    def go_page(self, page_label: str, thresh: float = 0.82) -> bool:
+        token = page_label.split()[-1].upper().replace(" ", "_")
+        name = f"strona_{token}"
+        _, _, w, h = self.win.region
+        roi = (int(w * 0.05), int(h * 0.82), int(w * 0.9), int(h * 0.16))
+        frame = self._frame()
+        m = self.tm.find(frame, name, thresh=thresh, roi=roi, multi_scale=True)
+        if not m:
+            return False
+        L, T, _, _ = self.win.region
+        cx, cy = m["center"]
+        self._safe_click(L + cx, T + cy)
+        time.sleep(0.25)
+        return True
 
-def open_panel(self):
-self.win.focus()
-if not self.dry:
-pyautogui.hotkey("ctrl", "x")
-time.sleep(0.35)
+    def _find_row_by_text(self, target_text: str):
+        frame = self._frame()
+        h, w = frame.shape[:2]
+        roi = frame[int(h * 0.16):int(h * 0.70), int(w * 0.05):int(w * 0.55)]
+        if self.reader is None:
+            return None
+        results = self.reader.readtext(roi)
+        target_low = target_text.lower().strip()
+        for bbox, text, _ in results:
+            if text.lower().strip() == target_low:
+                (x0, y0), (x1, y1) = bbox[0], bbox[2]
+                return int((x0 + x1) // 2), int((y0 + y1) // 2)
+        return None
 
-
-def go_page(self, page_label: str, thresh=0.82):
-token = page_label.split()[-1].upper().replace(' ', '_')
-name = f"strona_{token}"
-_, _, w, h = self.win.region
-roi = (int(w*0.05), int(h*0.82), int(w*0.9), int(h*0.16))
-frame = self._frame()
-m = self.tm.find(frame, name, thresh=thresh, roi=roi, multi_scale=True)
-if not m:
-return False
-L, T, _, _ = self.win.region
-cx, cy = m["center"]
-self._safe_click(L + cx, T + cy)
-time.sleep(0.25)
-return True
-
-
-def _find_row_by_text(self, target_text: str):
-frame = self._frame()
-h, w = frame.shape[:2]
-roi = frame[int(h*0.16):int(h*0.70), int(w*0.05):int(w*0.55)]
-if self.reader is None:
-return None
-results = self.reader.readtext(roi)
-target_low = target_text.lower().strip()
-best = None
-for bbox, text, conf in results:
-return False

--- a/agent/template_matcher.py
+++ b/agent/template_matcher.py
@@ -1,86 +1,106 @@
 from __future__ import annotations
-self.method = method
-self.cache = {}
+
+from pathlib import Path
+from math import hypot
+
+import cv2
+import numpy as np
 
 
-def load(self, name: str):
-if name in self.cache:
-return self.cache[name]
-p = self.dir / f"{name}.png"
-img = cv2.imread(str(p), cv2.IMREAD_GRAYSCALE)
-if img is None:
-raise FileNotFoundError(f"Brak szablonu: {p}")
-# lekkie odszumianie poprawia trafienie na różnych UI
-img = cv2.GaussianBlur(img, (3,3), 0)
-self.cache[name] = img
-return img
+class TemplateMatcher:
+    def __init__(self, templates_dir: str = "assets/templates", method: int = cv2.TM_CCOEFF_NORMED):
+        self.dir = Path(templates_dir)
+        self.method = method
+        self.cache = {}
 
+    def load(self, name: str):
+        if name in self.cache:
+            return self.cache[name]
+        p = self.dir / f"{name}.png"
+        img = cv2.imread(str(p), cv2.IMREAD_GRAYSCALE)
+        if img is None:
+            raise FileNotFoundError(f"Brak szablonu: {p}")
+        img = cv2.GaussianBlur(img, (3, 3), 0)
+        self.cache[name] = img
+        return img
 
-def _prep(self, frame_bgr, roi):
-if roi is not None:
-x, y, w, h = roi
-crop = frame_bgr[y:y+h, x:x+w]
-else:
-x = y = 0
-h, w = frame_bgr.shape[:2]
-crop = frame_bgr
-gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
-return gray, x, y
+    def _prep(self, frame_bgr, roi):
+        if roi is not None:
+            x, y, w, h = roi
+            crop = frame_bgr[y:y + h, x:x + w]
+        else:
+            x = y = 0
+            h, w = frame_bgr.shape[:2]
+            crop = frame_bgr
+        gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
+        return gray, x, y
 
+    def find(self, frame_bgr: np.ndarray, name: str, thresh=0.82,
+             roi=None, multi_scale=False, scales=(1.0, 0.9, 1.1)):
+        gray, offx, offy = self._prep(frame_bgr, roi)
+        tpl0 = self.load(name)
+        best = None
+        for s in ([1.0] if not multi_scale else scales):
+            tpl = cv2.resize(
+                tpl0,
+                (max(1, int(tpl0.shape[1] * s)),
+                 max(1, int(tpl0.shape[0] * s))),
+                interpolation=cv2.INTER_AREA,
+            )
+            if tpl.shape[0] >= gray.shape[0] or tpl.shape[1] >= gray.shape[1]:
+                continue
+            res = cv2.matchTemplate(gray, tpl, self.method)
+            _, max_val, _, max_loc = cv2.minMaxLoc(res)
+            if max_val >= thresh:
+                x, y = max_loc
+                bw, bh = tpl.shape[1], tpl.shape[0]
+                cand = {
+                    "rect": (offx + x, offy + y, bw, bh),
+                    "center": (offx + x + bw // 2, offy + y + bh // 2),
+                    "score": float(max_val),
+                }
+                if best is None or cand["score"] > best["score"]:
+                    best = cand
+        return best
 
-def find(self, frame_bgr: np.ndarray, name: str, thresh=0.82,
-roi=None, multi_scale=False, scales=(1.0, 0.9, 1.1)):
-gray, offx, offy = self._prep(frame_bgr, roi)
-tpl0 = self.load(name)
-best = None
-for s in ([1.0] if not multi_scale else scales):
-tpl = cv2.resize(tpl0, (max(1, int(tpl0.shape[1]*s)),
-max(1, int(tpl0.shape[0]*s))), interpolation=cv2.INTER_AREA)
-if tpl.shape[0] >= gray.shape[0] or tpl.shape[1] >= gray.shape[1]:
-continue
-res = cv2.matchTemplate(gray, tpl, self.method)
-_, max_val, _, max_loc = cv2.minMaxLoc(res)
-if max_val >= thresh:
-x, y = max_loc
-bw, bh = tpl.shape[1], tpl.shape[0]
-cand = {
-"rect": (offx + x, offy + y, bw, bh),
-"center": (offx + x + bw // 2, offy + y + bh // 2),
-"score": float(max_val),
-}
-if best is None or cand["score"] > best["score"]:
-best = cand
-return best
+    def find_all(self, frame_bgr: np.ndarray, name: str, thresh=0.82,
+                 roi=None, multi_scale=True, scales=(1.0, 0.9, 1.1, 0.8), dedup_px=12):
+        """Zwraca listę dopasowań (słowniki) posortowanych po Y (od góry)."""
+        gray, offx, offy = self._prep(frame_bgr, roi)
+        tpl0 = self.load(name)
+        found = []
+        for s in ([1.0] if not multi_scale else scales):
+            tpl = cv2.resize(
+                tpl0,
+                (max(1, int(tpl0.shape[1] * s)),
+                 max(1, int(tpl0.shape[0] * s))),
+                interpolation=cv2.INTER_AREA,
+            )
+            if tpl.shape[0] >= gray.shape[0] or tpl.shape[1] >= gray.shape[1]:
+                continue
+            res = cv2.matchTemplate(gray, tpl, self.method)
+            ys, xs = np.where(res >= thresh)
+            for y, x in zip(ys, xs):
+                bw, bh = tpl.shape[1], tpl.shape[0]
+                cx, cy = offx + x + bw // 2, offy + y + bh // 2
+                score = float(res[y, x])
+                dup = False
+                for f in found:
+                    if hypot(f["center"][0] - cx, f["center"][1] - cy) < dedup_px:
+                        if score > f["score"]:
+                            f.update({
+                                "rect": (offx + x, offy + y, bw, bh),
+                                "center": (cx, cy),
+                                "score": score,
+                            })
+                        dup = True
+                        break
+                if not dup:
+                    found.append({
+                        "rect": (offx + x, offy + y, bw, bh),
+                        "center": (cx, cy),
+                        "score": score,
+                    })
+        found.sort(key=lambda d: d["center"][1])
+        return found
 
-
-def find_all(self, frame_bgr: np.ndarray, name: str, thresh=0.82,
-roi=None, multi_scale=True, scales=(1.0, 0.9, 1.1, 0.8), dedup_px=12):
-"""Zwraca listę dopasowań (słowniki) posortowanych po Y (od góry)."""
-gray, offx, offy = self._prep(frame_bgr, roi)
-tpl0 = self.load(name)
-found = []
-for s in ([1.0] if not multi_scale else scales):
-tpl = cv2.resize(tpl0, (max(1, int(tpl0.shape[1]*s)),
-max(1, int(tpl0.shape[0]*s))), interpolation=cv2.INTER_AREA)
-if tpl.shape[0] >= gray.shape[0] or tpl.shape[1] >= gray.shape[1]:
-continue
-res = cv2.matchTemplate(gray, tpl, self.method)
-ys, xs = np.where(res >= thresh)
-for y, x in zip(ys, xs):
-bw, bh = tpl.shape[1], tpl.shape[0]
-cx, cy = offx + x + bw // 2, offy + y + bh // 2
-score = float(res[y, x])
-# deduplikacja po bliskości
-dup = False
-for f in found:
-if hypot(f["center"][0]-cx, f["center"][1]-cy) < dedup_px:
-if score > f["score"]:
-f.update({"rect": (offx + x, offy + y, bw, bh),
-"center": (cx, cy), "score": score})
-dup = True
-break
-if not dup:
-found.append({"rect": (offx + x, offy + y, bw, bh),
-"center": (cx, cy), "score": score})
-found.sort(key=lambda d: d["center"][1])
-return found

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -5,55 +5,50 @@ import pyautogui
 
 
 class KeyHold:
-def __init__(self, dry: bool = False, active_fn=None):
-"""
-dry: jeśli True – nie wysyła realnych klawiszy (tryb testowy)
-active_fn: funkcja bezargumentowa -> bool (czy okno jest aktywne). Gdy False, watchdog zwalnia klawisze.
-"""
-self.down = set()
-self.lock = threading.Lock()
-self.dry = dry
-self.active_fn = active_fn
-self._stop = False
-self._wd = threading.Thread(target=self._watchdog, daemon=True)
-self._wd.start()
+    def __init__(self, dry: bool = False, active_fn=None):
+        """
+        dry: jeśli True – nie wysyła realnych klawiszy (tryb testowy)
+        active_fn: funkcja bezargumentowa -> bool (czy okno jest aktywne). Gdy False, watchdog zwalnia klawisze.
+        """
+        self.down = set()
+        self.lock = threading.Lock()
+        self.dry = dry
+        self.active_fn = active_fn
+        self._stop = False
+        self._wd = threading.Thread(target=self._watchdog, daemon=True)
+        self._wd.start()
 
+    def _watchdog(self):
+        while not self._stop:
+            if self.active_fn is not None:
+                try:
+                    if not self.active_fn():
+                        self.release_all()
+                except Exception:
+                    pass
+            time.sleep(0.5)
 
-def _watchdog(self):
-while not self._stop:
-if self.active_fn is not None:
-try:
-if not self.active_fn():
-self.release_all()
-except Exception:
-pass
-time.sleep(0.5)
+    def stop(self):
+        self._stop = True
+        self.release_all()
 
+    def press(self, key: str):
+        with self.lock:
+            if key not in self.down:
+                if not self.dry:
+                    pyautogui.keyDown(key)
+                self.down.add(key)
 
-def stop(self):
-self._stop = True
-self.release_all()
+    def release(self, key: str):
+        with self.lock:
+            if key in self.down:
+                if not self.dry:
+                    pyautogui.keyUp(key)
+                self.down.remove(key)
 
-
-def press(self, key: str):
-with self.lock:
-if key not in self.down:
-if not self.dry:
-pyautogui.keyDown(key)
-self.down.add(key)
-
-
-def release(self, key: str):
-with self.lock:
-if key in self.down:
-if not self.dry:
-pyautogui.keyUp(key)
-self.down.remove(key)
-
-
-def release_all(self):
-with self.lock:
-if not self.dry:
-for k in list(self.down):
-pyautogui.keyUp(k)
-self.down.clear()
+    def release_all(self):
+        with self.lock:
+            if not self.dry:
+                for k in list(self.down):
+                    pyautogui.keyUp(k)
+            self.down.clear()

--- a/tools/ds_health.py
+++ b/tools/ds_health.py
@@ -1,12 +1,16 @@
 from pathlib import Path
 import statistics as st
+
 root = Path("datasets/mt2")
-sizes=[]
-counts={0:0,1:0,2:0}
-for lbl in (root/"labels"/"train").glob("*.txt"):
-for ln in lbl.read_text().splitlines():
-c,cx,cy,w,h = ln.split()
-counts[int(c)] += 1
-sizes.append(float(w)*float(h))
+sizes = []
+counts = {0: 0, 1: 0, 2: 0}
+
+for lbl in (root / "labels" / "train").glob("*.txt"):
+    for ln in lbl.read_text().splitlines():
+        c, cx, cy, w, h = ln.split()
+        counts[int(c)] += 1
+        sizes.append(float(w) * float(h))
+
 print("bbox per class:", counts)
-if sizes: print("median bbox area:", st.median(sizes))
+if sizes:
+    print("median bbox area:", st.median(sizes))


### PR DESCRIPTION
## Summary
- restore indentation and structure for dataset health script
- rebuild Teleporter, TemplateMatcher, and other agent helpers with proper blocks
- normalize KeyHold, ChannelSwitcher, CycleFarm, and detector code indentation

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68ac623c09dc8330a6dec74f6c30ba71