### PR TITLE
Align GUI cooldown key with CycleFarm

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -340,7 +340,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 "sweep_ms": int(self.sweep_ms.value()),
                 "idle_sec": float(self.idle_sec.value()),
             },
-            "cooldowns": {"slot_minutes": int(self.cooldown_spin.value())},
+            "cooldowns": {"slot_min": int(self.cooldown_spin.value())},
         }
         return cfg
 


### PR DESCRIPTION
## Summary
- rename `slot_minutes` to `slot_min` in GUI config builder to match CycleFarm expectation

## Testing
- `python -m py_compile gui/app.py agent/cycle.py`
- manual script to verify changing GUI spin value updates `CycleFarm.cooldown_min`


------
https://chatgpt.com/codex/tasks/task_e_68ad5264f9908330a6a696048a64530c