### PR TITLE
Add timeout to window locator and handle failure

### DIFF
--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -26,7 +26,8 @@ class CycleFarm:
     def __init__(self, cfg: dict):
         self.cfg = cfg
         self.win = WindowCapture(cfg["window"]["title_substr"])
-        assert self.win.locate()
+        if not self.win.locate(timeout=5):
+            raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
 
         self.dry = cfg.get("dry_run", False)
         self.tp = Teleporter(self.win, use_ocr=True, dry=self.dry)

--- a/agent/infer_kbd.py
+++ b/agent/infer_kbd.py
@@ -15,7 +15,8 @@ class KbdVisionAgent:
         self.net.eval()
 
     def run(self):
-        assert self.win.locate()
+        if not self.win.locate(timeout=5):
+            raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
         while True:
             t0=time.time()
             fr = self.win.grab(); frame = np.array(fr)[:,:,:3]

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -12,7 +12,8 @@ class WasdVisionAgent:
         self.hd = None
 
     def run(self):
-        assert self.win.locate(), "Nie znaleziono okna – sprawdź title_substr"
+        if not self.win.locate(timeout=5):
+            raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
         self.hd = HuntDestroy(self.cfg, self.win)
         while True:
             self.hd.step()

--- a/recorder/window_capture.py
+++ b/recorder/window_capture.py
@@ -17,10 +17,25 @@ class WindowCapture:
         self.region = None       # (left, top, width, height)
         self.sct = mss.mss()
 
-    def locate(self) -> bool:
-        """Znajdź okno po fragmencie tytułu i ustaw region."""
+    def locate(self, timeout: float | None = None) -> bool:
+        """Znajdź okno po fragmencie tytułu i ustaw region.
+
+        Parameters
+        ----------
+        timeout: float | None
+            Maksymalny czas oczekiwania w sekundach. ``None`` oznacza nieskończone
+            oczekiwanie.
+
+        Returns
+        -------
+        bool
+            ``True`` jeśli okno zostało znalezione, ``False`` w przeciwnym razie.
+        """
         needle = (self.title_substr or "").lower()
+        start = time.time()
+        attempts = 0
         while True:
+            attempts += 1
             wins = [w for w in gw.getAllWindows() if needle in (w.title or "").lower()]
             if wins:
                 w = wins[0]
@@ -33,6 +48,8 @@ class WindowCapture:
                 self.win = w
                 self.update_region()
                 return True
+            if timeout is not None and (time.time() - start) >= timeout:
+                return False
             time.sleep(self.poll_sec)
 
     def update_region(self):

--- a/tools/capture_template.py
+++ b/tools/capture_template.py
@@ -4,8 +4,9 @@ from recorder.window_capture import WindowCapture
 
 
 out = Path("assets/templates"); out.mkdir(parents=True, exist_ok=True)
-wc = WindowCapture("Metin2") # fragment tytułu
-wc.locate()
+wc = WindowCapture("Metin2")  # fragment tytułu
+if not wc.locate(timeout=5):
+    raise RuntimeError("Nie znaleziono okna")
 frame = np.array(wc.grab())[:,:,:3]
 # ustaw ROI ręcznie na start
 x,y,w,h = 1000, 80, 90, 30


### PR DESCRIPTION
## Summary
- add `timeout` and attempt counting to `WindowCapture.locate`
- handle `locate` failures across GUI, agents, and tools with user feedback

## Testing
- `python -m py_compile recorder/window_capture.py gui/app.py agent/infer_wasd.py agent/cycle.py agent/infer_kbd.py tools/capture_template.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad55a5cd148330a540a16ae5a4d9b9