### PR TITLE
Add pywin32 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torch==2.8.0
 torchvision==0.23.0
 Pillow==11.3.0
 pynput==1.8.1
+pywin32>=306


### PR DESCRIPTION
## Summary
- include pywin32>=306 in requirements.txt

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement pywin32>=306)


------
https://chatgpt.com/codex/tasks/task_e_68ad71665a1483308e1d5e47ca1cd07a