### PR TITLE
feat: parse channel and teleport config

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,87 @@
+"""Agent configuration helpers.
+
+This module provides a small wrapper around the YAML configuration file used by
+the project.  It parses the teleport locations and channel list during
+initialisation and exposes helper methods allowing the user to modify these
+lists and save the configuration back to disk.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+
+import yaml
+
+
+@dataclass
+class TeleportSlot:
+    """Single teleport location defined by page and slot number."""
+
+    page: str
+    slot: int
+
+
+@dataclass
+class AgentConfig:
+    """Wrapper around the agent configuration dictionary.
+
+    Attributes
+    ----------
+    data:
+        Raw configuration dictionary used by the rest of the codebase.
+    teleport_slots:
+        List of :class:`TeleportSlot` objects parsed from ``teleport.slots``.
+    channels:
+        List of channel numbers available to the agent.
+    """
+
+    data: Dict[str, Any]
+    teleport_slots: List[TeleportSlot] = field(default_factory=list)
+    channels: List[int] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Loading / saving
+    # ------------------------------------------------------------------
+    @classmethod
+    def load(cls, path: str = "config/agent.yaml") -> "AgentConfig":
+        """Load configuration from ``path`` and parse custom fields."""
+
+        with open(path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        slots = [TeleportSlot(**s) for s in raw.get("teleport", {}).get("slots", [])]
+        channels = list(raw.get("channels", []))
+        return cls(raw, slots, channels)
+
+    def save(self, path: str = "config/agent.yaml") -> None:
+        """Serialise configuration back to YAML file."""
+
+        self.data.setdefault("teleport", {})["slots"] = [s.__dict__ for s in self.teleport_slots]
+        self.data["channels"] = list(self.channels)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(self.data, f, allow_unicode=True)
+
+    # ------------------------------------------------------------------
+    # Mutation helpers
+    # ------------------------------------------------------------------
+    def add_channel(self, ch: int) -> None:
+        """Add a channel number if it is not already present."""
+
+        if ch not in self.channels:
+            self.channels.append(ch)
+
+    def remove_channel(self, ch: int) -> None:
+        """Remove channel number if present."""
+
+        if ch in self.channels:
+            self.channels.remove(ch)
+
+    def add_slot(self, page: str, slot: int) -> None:
+        """Append a new teleport slot definition."""
+
+        self.teleport_slots.append(TeleportSlot(page, slot))
+
+    def remove_slot(self, page: str, slot: int) -> None:
+        """Remove a teleport slot matching ``page`` and ``slot``."""
+
+        self.teleport_slots = [s for s in self.teleport_slots if not (s.page == page and s.slot == slot)]

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -3,13 +3,44 @@ import time
 import numpy as np
 from recorder.window_capture import WindowCapture
 from .hunt_destroy import HuntDestroy
+from . import AgentConfig, TeleportSlot
 
 class WasdVisionAgent:
     def __init__(self, cfg):
+        """Create a vision agent using ``cfg`` configuration.
+
+        ``cfg`` may be either a raw configuration dictionary or an
+        :class:`agent.AgentConfig` instance.  The teleport slots and channel
+        list are parsed during initialisation so that the user may modify them
+        later through :meth:`set_teleport_slots` and :meth:`set_channels`.
+        """
+
+        if isinstance(cfg, AgentConfig):
+            self.channels = list(cfg.channels)
+            self.teleport_slots = list(cfg.teleport_slots)
+            cfg = cfg.data
+        else:
+            self.channels = list(cfg.get("channels", []))
+            self.teleport_slots = [TeleportSlot(**s) for s in cfg.get("teleport", {}).get("slots", [])]
         self.cfg = cfg
         self.win = WindowCapture(cfg['window']['title_substr'])
         self.period = 1 / 15
         self.hd = None
+
+    # ------------------------------------------------------------------
+    # Public mutators allowing user customisation
+    # ------------------------------------------------------------------
+    def set_channels(self, channels: list[int]) -> None:
+        """Replace the channel list used by the agent."""
+
+        self.channels = list(channels)
+        self.cfg["channels"] = list(channels)
+
+    def set_teleport_slots(self, slots: list[TeleportSlot]) -> None:
+        """Replace the teleport slot definitions."""
+
+        self.teleport_slots = list(slots)
+        self.cfg.setdefault("teleport", {})["slots"] = [s.__dict__ for s in slots]
 
     def run(self):
         if not self.win.locate(timeout=5):

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -16,3 +16,9 @@ stuck:
   min_flow_mag: 0.7
   rotate_ms_on_stuck: 250
 priority: ["boss","metin","potwory"]
+teleport:
+  slots:
+    - {page: "Strona I", slot: 1}
+    - {page: "Strona I", slot: 2}
+    # … kolejne wpisy
+channels: [1,2,3,4,5,6,7,8]


### PR DESCRIPTION
## Summary
- extend `config/agent.yaml` with teleport slots and channel list
- add `AgentConfig` helper to parse and edit teleport and channel settings
- allow `WasdVisionAgent` to access and update channel and teleport data

## Testing
- `python -m py_compile agent/__init__.py agent/infer_wasd.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad7170f12c83308556decf06f6e495