### PR TITLE
Use KeyHold for teleport panel keys and extend VK mapping

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -7,6 +7,7 @@ import easyocr
 
 from recorder.window_capture import WindowCapture
 from .template_matcher import TemplateMatcher
+from .wasd import KeyHold
 
 pyautogui.PAUSE = 0.02
 
@@ -26,6 +27,7 @@ class Teleporter:
         self.tm = TemplateMatcher(templates_dir)
         self.reader = easyocr.Reader(["pl", "en"], gpu=False) if use_ocr else None
         self.dry = dry
+        self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
 
     def _frame(self) -> np.ndarray:
         fr = self.win.grab()
@@ -40,7 +42,11 @@ class Teleporter:
     def open_panel(self) -> None:
         self.win.focus()
         if not self.dry:
-            pyautogui.hotkey("ctrl", "x")
+            self.keys.press("ctrl")
+            self.keys.press("x")
+            time.sleep(0.05)
+            self.keys.release("x")
+            self.keys.release("ctrl")
             time.sleep(0.35)
 
     def go_page(self, page_label: str, thresh: float = 0.82) -> bool:

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -11,6 +11,16 @@ VK_CODES = {
     "d": ord("D"),
     "shift": win32con.VK_SHIFT,
     "space": win32con.VK_SPACE,
+    "ctrl": win32con.VK_CONTROL,
+    "x": ord("X"),
+    "1": ord("1"),
+    "2": ord("2"),
+    "3": ord("3"),
+    "4": ord("4"),
+    "5": ord("5"),
+    "6": ord("6"),
+    "7": ord("7"),
+    "8": ord("8"),
 }
 
 


### PR DESCRIPTION
## Summary
- map ctrl, x and numeric keys 1-8 in VK_CODES
- send Ctrl+X to open teleport panel using KeyHold instead of pyautogui hotkey

## Testing
- `python -m py_compile agent/wasd.py agent/teleport.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad7201a9448330afbc925f6433322c