### PR TITLE
Use configurable template directory with validation

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import time
+import os
 import numpy as np
 import pyautogui
 from recorder.window_capture import WindowCapture
@@ -12,8 +13,14 @@ class ChannelSwitcher:
     Wymaga szablonów: assets/templates/ch1.png ... ch8.png
     """
 
-    def __init__(self, win: WindowCapture, templates_dir: str = "assets/templates", dry: bool = False):
+    def __init__(self, win: WindowCapture, templates_dir: str, dry: bool = False):
         self.win = win
+        if not os.path.isdir(templates_dir):
+            raise FileNotFoundError(f"Brak katalogu z szablonami: {templates_dir}")
+        required = [f"ch{i}.png" for i in range(1, 9)]
+        missing = [p for p in required if not os.path.isfile(os.path.join(templates_dir, p))]
+        if missing:
+            raise FileNotFoundError(f"Brak plików w {templates_dir}: {', '.join(missing)}")
         self.tm = TemplateMatcher(templates_dir)
         self.dry = dry
 

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -30,8 +30,9 @@ class CycleFarm:
             raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
 
         self.dry = cfg.get("dry_run", False)
-        self.tp = Teleporter(self.win, use_ocr=True, dry=self.dry)
-        self.ch = ChannelSwitcher(self.win, dry=self.dry)
+        tdir = cfg["templates_dir"]
+        self.tp = Teleporter(self.win, tdir, use_ocr=True, dry=self.dry)
+        self.ch = ChannelSwitcher(self.win, tdir, dry=self.dry)
         self.agent = HuntDestroy(cfg, self.win)
         self.det = ObjectDetector(cfg["detector"]["model_path"], cfg["detector"]["classes"])
         self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import os
 import numpy as np
 import pyautogui
 import easyocr
@@ -21,8 +22,14 @@ class Teleporter:
     Wymaga szablonów: wczytaj.png, strona_I.png..strona_VIII.png
     """
 
-    def __init__(self, win: WindowCapture, use_ocr: bool = True, templates_dir: str = "assets/templates", dry: bool = False):
+    def __init__(self, win: WindowCapture, templates_dir: str, use_ocr: bool = True, dry: bool = False):
         self.win = win
+        if not os.path.isdir(templates_dir):
+            raise FileNotFoundError(f"Brak katalogu z szablonami: {templates_dir}")
+        required = ["wczytaj.png"] + [f"strona_{r}.png" for r in ["I","II","III","IV","V","VI","VII","VIII"]]
+        missing = [p for p in required if not os.path.isfile(os.path.join(templates_dir, p))]
+        if missing:
+            raise FileNotFoundError(f"Brak plików w {templates_dir}: {', '.join(missing)}")
         self.tm = TemplateMatcher(templates_dir)
         self.reader = easyocr.Reader(["pl", "en"], gpu=False) if use_ocr else None
         self.dry = dry

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -1,5 +1,6 @@
 window:
   title_substr: "Metin2"
+templates_dir: "assets/templates"
 controls:
   keys: {forward: "w", left: "a", back: "s", right: "d"}
 detector:

--- a/gui/app.py
+++ b/gui/app.py
@@ -346,6 +346,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 "idle_sec": float(self.idle_sec.value()),
             },
             "cooldowns": {"slot_min": int(self.cooldown_spin.value())},
+            "templates_dir": "assets/templates",
         }
         return cfg
 
@@ -380,7 +381,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 if not win.locate(timeout=5):
                     self.set_status("Nie znaleziono okna.")
                     return
-                tp = Teleporter(win, use_ocr=True)
+                tp = Teleporter(win, cfg["templates_dir"], use_ocr=True)
                 ok = tp.teleport(point, side)
                 if not ok:
                     self.set_status("Nie udało się kliknąć elementów w panelu teleportu (sprawdź OCR/templates)")
@@ -419,7 +420,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.set_status("Nie znaleziono okna.")
                 return
             ch = int(self.channel_combo.currentText().replace("CH", ""))
-            ok = ChannelSwitcher(win).switch(ch)
+            ok = ChannelSwitcher(win, cfg["templates_dir"]).switch(ch)
             msg = f"Zmieniono kanał na CH{ch}" if ok else "Nie znaleziono przycisku CH – sprawdź szablony."
             self.set_status(msg)
         except Exception as exc:


### PR DESCRIPTION
## Summary
- add `templates_dir` to agent config and GUI builder
- load Teleporter and ChannelSwitcher templates from configured directory and verify required images exist
- pass template directory through agent lifecycle and GUI utilities

## Testing
- `python -m py_compile agent/teleport.py agent/channel.py agent/cycle.py gui/app.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad720096fc833095acc5d1813788bd