### PR TITLE
Refactor KeyHold to use SendInput and add tests

### DIFF
--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
 import threading
 import time
-import win32api
-import win32con
+
+# Selected virtual-key codes used by the agent.  These values normally come
+# from ``win32con`` but are duplicated here to keep the module importable on
+# non-Windows platforms (e.g. during tests in dry mode).
+VK_SHIFT = 0x10
+VK_SPACE = 0x20
+VK_CONTROL = 0x11
 
 VK_CODES = {
     "w": ord("W"),
     "a": ord("A"),
     "s": ord("S"),
     "d": ord("D"),
-    "shift": win32con.VK_SHIFT,
-    "space": win32con.VK_SPACE,
-    "ctrl": win32con.VK_CONTROL,
+    "shift": VK_SHIFT,
+    "space": VK_SPACE,
+    "ctrl": VK_CONTROL,
     "x": ord("X"),
     "1": ord("1"),
     "2": ord("2"),
@@ -24,6 +32,77 @@ VK_CODES = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Helpers around the ``SendInput`` Windows API
+# ---------------------------------------------------------------------------
+
+PUL = ctypes.POINTER(ctypes.c_ulong)
+
+
+class KEYBDINPUT(ctypes.Structure):
+    _fields_ = [
+        ("wVk", wintypes.WORD),
+        ("wScan", wintypes.WORD),
+        ("dwFlags", wintypes.DWORD),
+        ("time", wintypes.DWORD),
+        ("dwExtraInfo", PUL),
+    ]
+
+
+class _INPUTUNION(ctypes.Union):
+    _fields_ = [("ki", KEYBDINPUT)]
+
+
+class INPUT(ctypes.Structure):
+    _anonymous_ = ("u",)
+    _fields_ = [("type", wintypes.DWORD), ("u", _INPUTUNION)]
+
+
+INPUT_KEYBOARD = 1
+KEYEVENTF_KEYUP = 0x0002
+
+
+if hasattr(ctypes, "windll"):
+    _user32 = ctypes.windll.user32
+else:
+    _user32 = None
+
+
+def _send_input(vk: int, flags: int) -> None:
+    """Low level wrapper over ``SendInput``.
+
+    When running on non-Windows platforms ``_user32`` is ``None`` and the
+    function becomes a no-op which keeps the module importable for tests.
+    """
+
+    if _user32 is None:
+        return
+
+    scan = _user32.MapVirtualKeyW(vk, 0)
+    extra = ctypes.c_ulong(0)
+    ki = KEYBDINPUT(
+        wVk=vk,
+        wScan=scan,
+        dwFlags=flags,
+        time=0,
+        dwExtraInfo=ctypes.pointer(extra),
+    )
+    inp = INPUT(type=INPUT_KEYBOARD, ki=ki)
+    _user32.SendInput(1, ctypes.byref(inp), ctypes.sizeof(inp))
+
+
+def key_down(vk: int) -> None:
+    """Simulate key press for the given virtual-key code."""
+
+    _send_input(vk, 0)
+
+
+def key_up(vk: int) -> None:
+    """Simulate key release for the given virtual-key code."""
+
+    _send_input(vk, KEYEVENTF_KEYUP)
+
+
 class KeyHold:
     def __init__(self, dry: bool = False, active_fn=None):
         """
@@ -34,12 +113,6 @@ class KeyHold:
         self.lock = threading.Lock()
         self.dry = dry
         self.active_fn = active_fn
-        self.hwnd = None
-        if active_fn is not None:
-            try:
-                self.hwnd = getattr(active_fn.__self__, "hwnd", lambda: None)()
-            except Exception:
-                self.hwnd = None
         self._stop = False
         self._wd = threading.Thread(target=self._watchdog, daemon=True)
         self._wd.start()
@@ -61,20 +134,20 @@ class KeyHold:
     def press(self, key: str):
         with self.lock:
             if key not in self.down:
-                if not self.dry and self.hwnd:
-                    win32api.PostMessage(self.hwnd, win32con.WM_KEYDOWN, VK_CODES[key], 0)
+                if not self.dry and (self.active_fn is None or self.active_fn()):
+                    key_down(VK_CODES[key])
                 self.down.add(key)
 
     def release(self, key: str):
         with self.lock:
             if key in self.down:
-                if not self.dry and self.hwnd:
-                    win32api.PostMessage(self.hwnd, win32con.WM_KEYUP, VK_CODES[key], 0)
+                if not self.dry and (self.active_fn is None or self.active_fn()):
+                    key_up(VK_CODES[key])
                 self.down.remove(key)
 
     def release_all(self):
         with self.lock:
-            if not self.dry and self.hwnd:
+            if not self.dry:
                 for k in list(self.down):
-                    win32api.PostMessage(self.hwnd, win32con.WM_KEYUP, VK_CODES[k], 0)
+                    key_up(VK_CODES[k])
             self.down.clear()

--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import types
+from unittest.mock import patch
+
+
+# Make repository root importable and provide a stub ``yaml`` module so that the
+# :mod:`agent` package can be imported without optional dependencies.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+
+import agent.wasd as wasd
+
+
+def test_dry_mode_skips_sendinput():
+    """No SendInput calls should be made when dry mode is enabled."""
+
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up:
+        kh = wasd.KeyHold(dry=True, active_fn=lambda: True)
+        kh.press("w")
+        kh.release("w")
+        kh.release_all()
+        kh.stop()
+
+    assert mock_down.call_count == 0
+    assert mock_up.call_count == 0
+
+
+def test_press_release_calls_sendinput_when_active():
+    """In active mode the helper functions should be invoked."""
+
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up:
+        kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+        kh.press("w")
+        kh.release("w")
+        kh.stop()
+
+    mock_down.assert_called_once_with(wasd.VK_CODES["w"])
+    mock_up.assert_called_once_with(wasd.VK_CODES["w"])
+
+
+def test_press_skipped_when_window_inactive():
+    """active_fn returning False should suppress key presses."""
+
+    with patch.object(wasd, "key_down") as mock_down:
+        kh = wasd.KeyHold(dry=False, active_fn=lambda: False)
+        kh.press("w")
+        kh.stop()
+
+    mock_down.assert_not_called()
+


### PR DESCRIPTION
## Summary
- send keyboard events via Windows SendInput API and add key_down/key_up helpers
- refactor KeyHold to drop window handle and honor active window checks
- add unit tests ensuring dry mode and focus checks prevent SendInput calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9a5952848330b95f70b5f3b1ce94