### PR TITLE
Add low-level keyboard hook for scan-code logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,17 @@ PY
 ## Configuration and Templates
 - Agent settings such as window title, detector paths and movement policy live in [`config/agent.yaml`](config/agent.yaml).
 - UI templates for channel buttons, teleport pages and other elements are stored in [`assets/templates/`](assets/templates/). Use `tools/capture_template.py` to capture additional templates.
+
+## Recording Input
+
+`recorder/capture.py` logs mouse clicks and raw keyboard scan codes. The
+keyboard listener relies on a low‑level hook provided by the
+[`keyboard`](https://github.com/boppreh/keyboard) package.
+
+* **Windows** – uses the native `SetWindowsHookEx` API through the library.
+* **Linux** – reads events from `/dev/input`; this normally requires root
+  privileges and may not function under Wayland compositors.
+* **macOS** – only partially supported and may need additional accessibility
+  permissions.
+
+If the hook cannot be installed only mouse clicks will be recorded.

--- a/recorder/align_wasd.py
+++ b/recorder/align_wasd.py
@@ -1,17 +1,22 @@
 import json, cv2, numpy as np
 from pathlib import Path
 
+# Mapping of raw scan codes to WASD keys
+SCANCODE_TO_KEY = {17: 'w', 30: 'a', 31: 's', 32: 'd'}
+
 def align(video_path, events_path, out_dir, image_size=224, region=None):
     Path(out_dir).mkdir(parents=True, exist_ok=True)
     keys = []
-    with open(events_path,'r') as f:
+    with open(events_path, 'r') as f:
         for line in f:
             e = json.loads(line)
             if e['kind'] == 'key':
-                k = e['payload']['key'].lower()
-                if any(ch in k for ch in ['w','a','s','d']):
-                    keys.append((e['ts'], 'down' if e['payload'].get('down',False) else 'up', k))
-    held = { 'w':False,'a':False,'s':False,'d':False }
+                sc = e['payload'].get('scancode')
+                k = SCANCODE_TO_KEY.get(sc)
+                if k:
+                    down = e['payload'].get('down', False)
+                    keys.append((e['ts'], 'down' if down else 'up', k))
+    held = {'w': False, 'a': False, 's': False, 'd': False}
     cap = cv2.VideoCapture(video_path)
     fps = cap.get(cv2.CAP_PROP_FPS)
     idx=0; ok=True

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ torch==2.8.0
 torchvision==0.23.0
 Pillow==11.3.0
 pynput==1.8.1
+keyboard==0.13.5
 pywin32>=306

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+from unittest.mock import patch
+
+# Make repository root importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub heavy optional dependencies so recorder.capture can be imported
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+sys.modules.setdefault("mss", types.ModuleType("mss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+stub_pynput = types.ModuleType("pynput")
+class DummyListener:
+    def __init__(self, *a, **k):
+        pass
+    def start(self):
+        pass
+    def stop(self):
+        pass
+stub_pynput.mouse = types.SimpleNamespace(Listener=DummyListener)
+sys.modules.setdefault("pynput", stub_pynput)
+sys.modules.setdefault("pynput.mouse", stub_pynput.mouse)
+
+from recorder.capture import InputLogger
+
+
+def test_keyboard_hook_records_scancodes():
+    events = []
+
+    def fake_hook(cb):
+        fake_hook.cb = cb
+        return object()
+
+    stub_keyboard = types.SimpleNamespace(hook=fake_hook, unhook=lambda h: None)
+
+    with patch('recorder.capture._keyboard', stub_keyboard):
+        logger = InputLogger()
+        logger.start()
+        class E:
+            def __init__(self, sc, et):
+                self.scan_code = sc
+                self.event_type = et
+        fake_hook.cb(E(30, 'down'))
+        fake_hook.cb(E(30, 'up'))
+        logger.stop()
+        events = logger.flush()
+
+    assert events[0][2] == {'scancode': 30, 'down': True}
+    assert events[1][2] == {'scancode': 30, 'down': False}


### PR DESCRIPTION
## Summary
- capture raw keyboard scan codes using a low-level hook and expose them through `InputLogger`
- map recorded scan codes to WASD keys in the alignment helper
- document OS-specific keyboard hook limitations and add unit test for basic capture logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea9c7f66883308947643722bccc0f