### PR TITLE
feat: log scan and vk codes

### DIFF
--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -90,11 +90,33 @@ SCANCODES = {
     "8": 0x09,
 }
 
+# Reverse map allowing lookup by scan or virtual key code.
+REVERSE_SCANCODES = {v: k for k, v in SCANCODES.items()}
+
 # Keys that require the extended flag when sent via ``SendInput``.
 EXTENDED_KEYS = {"up", "down", "left", "right"}
 
 # Backwards compatibility: expose ``VK_CODES`` and helpers used in tests.
 VK_CODES = SCANCODES
+
+
+def resolve_key(payload: dict) -> str | None:
+    """Resolve key name from an event payload.
+
+    The payload may contain a textual ``key`` field or numeric ``scan``/``vk``
+    codes.  Returns ``None`` if the key cannot be determined.
+    """
+
+    k = payload.get("key")
+    if k:
+        return k
+    scan = payload.get("scan")
+    if scan in REVERSE_SCANCODES:
+        return REVERSE_SCANCODES[scan]
+    vk = payload.get("vk")
+    if vk in REVERSE_SCANCODES:
+        return REVERSE_SCANCODES[vk]
+    return None
 
 
 def key_down(scan: int, extended: bool = False) -> None:

--- a/recorder/align_wasd.py
+++ b/recorder/align_wasd.py
@@ -1,16 +1,21 @@
 import json, cv2, numpy as np
 from pathlib import Path
+from agent.wasd import resolve_key
 
 def align(video_path, events_path, out_dir, image_size=224, region=None):
     Path(out_dir).mkdir(parents=True, exist_ok=True)
     keys = []
-    with open(events_path,'r') as f:
+    with open(events_path, 'r') as f:
         for line in f:
             e = json.loads(line)
             if e['kind'] == 'key':
-                k = e['payload']['key'].lower()
-                if any(ch in k for ch in ['w','a','s','d']):
-                    keys.append((e['ts'], 'down' if e['payload'].get('down',False) else 'up', k))
+                p = e['payload']
+                k = resolve_key(p)
+                if not k:
+                    continue
+                k = k.lower()
+                if any(ch in k for ch in ['w', 'a', 's', 'd']):
+                    keys.append((e['ts'], 'down' if p.get('down', False) else 'up', k))
     held = { 'w':False,'a':False,'s':False,'d':False }
     cap = cv2.VideoCapture(video_path)
     fps = cap.get(cv2.CAP_PROP_FPS)

--- a/recorder/capture.py
+++ b/recorder/capture.py
@@ -19,11 +19,25 @@ class InputLogger:
 
     def on_press(self, key):
         with self._lock:
-            self.buffer.append((time.time(), 'key', {'key': str(key), 'down': True}))
+            payload = {'key': str(key), 'down': True}
+            vk = getattr(key, 'vk', None)
+            if vk is not None:
+                payload['vk'] = vk
+            scan = getattr(key, 'scan', None)
+            if scan is not None:
+                payload['scan'] = scan
+            self.buffer.append((time.time(), 'key', payload))
 
     def on_release(self, key):
         with self._lock:
-            self.buffer.append((time.time(), 'key', {'key': str(key), 'down': False}))
+            payload = {'key': str(key), 'down': False}
+            vk = getattr(key, 'vk', None)
+            if vk is not None:
+                payload['vk'] = vk
+            scan = getattr(key, 'scan', None)
+            if scan is not None:
+                payload['scan'] = scan
+            self.buffer.append((time.time(), 'key', payload))
 
     def flush(self):
         with self._lock:

--- a/tests/test_inputlogger.py
+++ b/tests/test_inputlogger.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import types
+
+# Make repository root importable and provide stub modules so that optional
+# dependencies are not required during testing.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+sys.modules.setdefault("mss", types.ModuleType("mss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+pynput_stub = types.ModuleType("pynput")
+pynput_stub.mouse = types.ModuleType("mouse")
+pynput_stub.keyboard = types.ModuleType("keyboard")
+sys.modules.setdefault("pynput", pynput_stub)
+sys.modules.setdefault("pynput.mouse", pynput_stub.mouse)
+sys.modules.setdefault("pynput.keyboard", pynput_stub.keyboard)
+
+from recorder.capture import InputLogger
+
+
+class DummyKey:
+    def __init__(self, vk, scan, name="a"):
+        self.vk = vk
+        self.scan = scan
+        self._name = name
+
+    def __str__(self):  # pragma: no cover - trivial
+        return self._name
+
+
+def test_logger_records_scan_and_vk():
+    logger = InputLogger()
+    key = DummyKey(vk=97, scan=0x1E, name='a')
+    logger.on_press(key)
+    events = logger.flush()
+    assert len(events) == 1
+    ts, kind, payload = events[0]
+    assert kind == 'key'
+    assert payload['key'] == str(key)
+    assert payload['down'] is True
+    assert payload.get('vk') == key.vk
+    assert payload.get('scan') == key.scan


### PR DESCRIPTION
## Summary
- record scan and virtual-key codes for keyboard events
- expose `resolve_key` to map event payloads back to key names
- teach WASD alignment to parse events via the new payload helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aea9cbdbfc8330bf0ea5071f97a876