### PR TITLE
refactor: centralize key codes

### DIFF
--- a/agent/keycodes.py
+++ b/agent/keycodes.py
@@ -1,0 +1,79 @@
+"""Centralised keyboard scan code definitions and helpers.
+
+This module exposes the mapping between human readable key names and the
+corresponding Windows scan codes used by the project.  Keeping the mapping in
+a dedicated module allows other parts of the codebase (for example the
+``agent`` runtime and the ``recorder`` utilities) to share a single source of
+truth for key identifiers.
+"""
+
+from __future__ import annotations
+
+# Mapping from a human‑friendly key name to its Windows scan code.  Only the
+# keys required by the project are included here.
+SCANCODES = {
+    "w": 0x11,
+    "a": 0x1E,
+    "s": 0x1F,
+    "d": 0x20,
+    "space": 0x39,
+    "shift": 0x2A,
+    "ctrl": 0x1D,
+    "alt": 0x38,
+    "x": 0x2D,
+    "1": 0x02,
+    "2": 0x03,
+    "3": 0x04,
+    "4": 0x05,
+    "5": 0x06,
+    "6": 0x07,
+    "7": 0x08,
+    "8": 0x09,
+}
+
+# Keys that require the extended flag when sent via ``SendInput``.  These keys
+# are not currently associated with scan codes in ``SCANCODES`` but are part of
+# the normalised key set understood by the project.
+EXTENDED_KEYS = {"up", "down", "left", "right"}
+
+# Backwards compatibility: expose ``VK_CODES`` under the same name that was
+# previously defined in :mod:`agent.wasd`.
+VK_CODES = SCANCODES
+
+
+# ---------------------------------------------------------------------------
+# ``pynput`` helpers
+# ---------------------------------------------------------------------------
+
+# Mapping of ``str(pynput.keyboard.Key)`` representations to the canonical key
+# names used above.  Character keys are handled separately.
+_PYNPUT_NAME_MAP = {
+    "Key.space": "space",
+    "Key.shift": "shift",
+    "Key.shift_r": "shift",
+    "Key.ctrl": "ctrl",
+    "Key.ctrl_r": "ctrl",
+    "Key.alt": "alt",
+    "Key.alt_r": "alt",
+    "Key.up": "up",
+    "Key.down": "down",
+    "Key.left": "left",
+    "Key.right": "right",
+}
+
+
+def pynput_key_name(key) -> str | None:
+    """Return a canonical key name for a ``pynput`` key object.
+
+    If the key is a character it is returned in lower case.  For special keys
+    the mapping above is used.  ``None`` is returned for keys that are not
+    recognised by the project.
+    """
+
+    try:
+        if hasattr(key, "char") and key.char is not None:
+            return key.char.lower()
+        return _PYNPUT_NAME_MAP.get(str(key))
+    except Exception:
+        return None
+

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -6,6 +6,8 @@ import threading
 import time
 import logging
 
+from .keycodes import SCANCODES, EXTENDED_KEYS, VK_CODES
+
 
 # ---------------------------------------------------------------------------
 # ``SendInput`` helpers working with scan codes
@@ -70,31 +72,6 @@ def _send_scan(scan: int, keyup: bool = False, extended: bool = False) -> None:
     _user32.SendInput(1, ctypes.byref(inp), ctypes.sizeof(inp))
 
 
-SCANCODES = {
-    "w": 0x11,
-    "a": 0x1E,
-    "s": 0x1F,
-    "d": 0x20,
-    "space": 0x39,
-    "shift": 0x2A,
-    "ctrl": 0x1D,
-    "alt": 0x38,
-    "x": 0x2D,
-    "1": 0x02,
-    "2": 0x03,
-    "3": 0x04,
-    "4": 0x05,
-    "5": 0x06,
-    "6": 0x07,
-    "7": 0x08,
-    "8": 0x09,
-}
-
-# Keys that require the extended flag when sent via ``SendInput``.
-EXTENDED_KEYS = {"up", "down", "left", "right"}
-
-# Backwards compatibility: expose ``VK_CODES`` and helpers used in tests.
-VK_CODES = SCANCODES
 
 
 def key_down(scan: int, extended: bool = False) -> None:

--- a/recorder/capture.py
+++ b/recorder/capture.py
@@ -7,6 +7,8 @@ import mss
 import numpy as np
 from pynput import mouse, keyboard
 
+from agent.keycodes import pynput_key_name
+
 class InputLogger:
     def __init__(self):
         self.buffer = []  # (ts, kind, payload)
@@ -18,12 +20,18 @@ class InputLogger:
                 self.buffer.append((time.time(), 'click', {'x': x, 'y': y, 'button': str(button)}))
 
     def on_press(self, key):
+        name = pynput_key_name(key)
+        if name is None:
+            return
         with self._lock:
-            self.buffer.append((time.time(), 'key', {'key': str(key), 'down': True}))
+            self.buffer.append((time.time(), 'key', {'key': name, 'down': True}))
 
     def on_release(self, key):
+        name = pynput_key_name(key)
+        if name is None:
+            return
         with self._lock:
-            self.buffer.append((time.time(), 'key', {'key': str(key), 'down': False}))
+            self.buffer.append((time.time(), 'key', {'key': name, 'down': False}))
 
     def flush(self):
         with self._lock:

--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 sys.modules.setdefault("yaml", types.ModuleType("yaml"))
 
 import agent.wasd as wasd
+import agent.keycodes as keycodes
 
 
 def test_dry_mode_skips_sendinput():
@@ -39,8 +40,8 @@ def test_press_release_calls_sendinput_when_active():
         kh.release("w")
         kh.stop()
 
-    mock_down.assert_called_once_with(wasd.VK_CODES["w"])
-    mock_up.assert_called_once_with(wasd.VK_CODES["w"])
+    mock_down.assert_called_once_with(keycodes.SCANCODES["w"])
+    mock_up.assert_called_once_with(keycodes.SCANCODES["w"])
 
 
 def test_press_skipped_when_window_inactive():


### PR DESCRIPTION
## Summary
- add shared `agent.keycodes` with scan code mapping and helpers
- use shared key mapping in `agent.wasd` and `recorder.capture`
- update tests to reference centralized key definitions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aea9cd6ddc8330aa9385cffe523d1a