### PR TITLE
Fix WASD key handling and add regression tests

### DIFF
--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -97,6 +97,19 @@ EXTENDED_KEYS = {"up", "down", "left", "right"}
 VK_CODES = SCANCODES
 
 
+def resolve_key(key: str) -> str:
+    """Normalize ``pynput``-style key names.
+
+    ``pynput`` represents special keys as ``Key.space`` etc.  For the purposes
+    of WASD handling we only care about the literal key name, so the ``Key.``
+    prefix is stripped before returning.
+    """
+
+    if isinstance(key, str) and key.startswith("Key."):
+        return key.split(".", 1)[1]
+    return key
+
+
 def key_down(scan: int, extended: bool = False) -> None:
     _send_scan(scan, extended=extended)
 

--- a/recorder/align_wasd.py
+++ b/recorder/align_wasd.py
@@ -24,12 +24,9 @@ def align(video_path, events_path, out_dir, image_size=224, region=None):
         ok, frame = cap.read(); idx+=1
         if not ok: break
         ts = idx / max(fps,1.0)
-        for (t,typ,k) in list(keys):
-            if abs(t - ts) <= 0.05:
-                if 'w' in k: held['w'] = (typ=='down')
-                if 'a' in k: held['a'] = (typ=='down')
-                if 's' in k: held['s'] = (typ=='down')
-                if 'd' in k: held['d'] = (typ=='down')
+        for (t, typ, k) in list(keys):
+            if abs(t - ts) <= 0.05 and k in ('w', 'a', 's', 'd'):
+                held[k] = typ == 'down'
         img = cv2.resize(frame, (image_size,image_size))
         y = np.array([held['w'],held['a'],held['s'],held['d']], dtype=np.float32)
         np.savez_compressed(Path(out_dir)/f"kbd_{idx:07d}.npz", img=img[:,:,::-1], y=y)

--- a/tests/test_wasd_align.py
+++ b/tests/test_wasd_align.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import types
+import json
+from unittest.mock import patch
+
+# Make repository root importable and stub optional modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+cv2_stub = types.SimpleNamespace(CAP_PROP_FPS=0)
+sys.modules.setdefault("cv2", cv2_stub)
+
+# Ensure the real numpy package is used even if previous tests stubbed it
+sys.modules.pop("numpy", None)
+import numpy as np
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+import agent.wasd as wasd
+from recorder import align_wasd
+
+
+def test_resolve_key_strips_prefix():
+    assert wasd.resolve_key("Key.space") == "space"
+    assert wasd.resolve_key("w") == "w"
+
+
+def test_align_ignores_non_wasd_keys(tmp_path):
+    events = [
+        {"ts": 0.05, "kind": "key", "payload": {"key": "space", "down": True}},
+        {"ts": 0.06, "kind": "key", "payload": {"key": "space", "down": False}},
+        {"ts": 0.25, "kind": "key", "payload": {"scancode": 17, "down": True}},
+        {"ts": 0.35, "kind": "key", "payload": {"scancode": 17, "down": False}},
+    ]
+    events_path = tmp_path / "events.jsonl"
+    with open(events_path, "w", encoding="utf-8") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+    video_path = tmp_path / "video.mp4"
+
+    frames = [np.zeros((2, 2, 3), dtype=np.uint8) for _ in range(3)]
+
+    class DummyCap:
+        def __init__(self, frames):
+            self.frames = frames
+            self.idx = 0
+
+        def get(self, prop):
+            return 10.0  # fps
+
+        def read(self):
+            if self.idx < len(self.frames):
+                frame = self.frames[self.idx]
+                self.idx += 1
+                return True, frame
+            return False, None
+
+        def release(self):
+            pass
+
+    def dummy_resize(frame, size):
+        return frame
+
+    saved = []
+
+    with patch.object(align_wasd.cv2, "CAP_PROP_FPS", 0, create=True), \
+         patch.object(align_wasd.cv2, "VideoCapture", lambda path: DummyCap(frames), create=True), \
+         patch.object(align_wasd.cv2, "resize", dummy_resize, create=True), \
+         patch.object(align_wasd.np, "savez_compressed", lambda path, img=None, y=None: saved.append(y)):
+        align_wasd.align(str(video_path), str(events_path), tmp_path)
+
+    assert [y.tolist() for y in saved] == [
+        [0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0],
+    ]


### PR DESCRIPTION
## Summary
- normalize `pynput` key names via `resolve_key`
- use exact equality when aligning WASD key events
- add test coverage for non-WASD keys and `resolve_key`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aebc5a9eb08330a29ff7e931f2049b