### PR TITLE
Improve virtual-key handling and key resolution

### DIFF
--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -39,8 +39,8 @@ def test_press_release_calls_sendinput_when_active():
         kh.release("w")
         kh.stop()
 
-    mock_down.assert_called_once_with(wasd.VK_CODES["w"])
-    mock_up.assert_called_once_with(wasd.VK_CODES["w"])
+    mock_down.assert_called_once_with(wasd.SCANCODES["w"])
+    mock_up.assert_called_once_with(wasd.SCANCODES["w"])
 
 
 def test_press_skipped_when_window_inactive():

--- a/tests/test_wasd_align.py
+++ b/tests/test_wasd_align.py
@@ -22,6 +22,16 @@ def test_resolve_key_strips_prefix():
     assert wasd.resolve_key("w") == "w"
 
 
+def test_resolve_key_from_scan():
+    sc = wasd.SCANCODES["w"]
+    assert wasd.resolve_key({"scan": sc}) == "w"
+
+
+def test_resolve_key_from_vk():
+    vk = wasd.VK_CODES["a"]
+    assert wasd.resolve_key({"vk": vk}) == "a"
+
+
 def test_align_ignores_non_wasd_keys(tmp_path):
     events = [
         {"ts": 0.05, "kind": "key", "payload": {"key": "space", "down": True}},


### PR DESCRIPTION
## Summary
- map Windows virtual-key codes and expose reverse lookup
- resolve keys from scan codes and virtual-key codes
- test key resolution for scan and vk fields and adjust KeyHold tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aebe1a8e548330bbe036dc33c60152