### PR TITLE
Add InputLogger release codes and resolve_key tests

### DIFF
--- a/recorder/capture.py
+++ b/recorder/capture.py
@@ -49,17 +49,41 @@ class InputLogger:
     # ``pynput`` compatibility helpers used in tests
     def on_press(self, key):  # pragma: no cover - simple passthrough
         from agent.wasd import resolve_key
+
+        payload = {"key": resolve_key(key), "down": True}
+
+        if isinstance(key, dict):
+            scan = key.get("scan")
+            vk = key.get("vk")
+        else:
+            scan = getattr(key, "scan", None)
+            vk = getattr(key, "vk", None)
+        if scan is not None:
+            payload["scan"] = scan
+        if vk is not None:
+            payload["vk"] = vk
+
         with self._lock:
-            self.buffer.append(
-                (time.time(), "key", {"key": resolve_key(str(key)), "down": True})
-            )
+            self.buffer.append((time.time(), "key", payload))
 
     def on_release(self, key):  # pragma: no cover - simple passthrough
         from agent.wasd import resolve_key
+
+        payload = {"key": resolve_key(key), "down": False}
+
+        if isinstance(key, dict):
+            scan = key.get("scan")
+            vk = key.get("vk")
+        else:
+            scan = getattr(key, "scan", None)
+            vk = getattr(key, "vk", None)
+        if scan is not None:
+            payload["scan"] = scan
+        if vk is not None:
+            payload["vk"] = vk
+
         with self._lock:
-            self.buffer.append(
-                (time.time(), "key", {"key": resolve_key(str(key)), "down": False})
-            )
+            self.buffer.append((time.time(), "key", payload))
 
     def start(self):
         """Begin capturing keyboard events using a low‑level hook."""

--- a/tests/test_recorder_keyboard.py
+++ b/tests/test_recorder_keyboard.py
@@ -54,3 +54,37 @@ def test_inputlogger_records_down_up_pairs():
         (1.0, "key", {"key": "a", "down": True}),
         (2.0, "key", {"key": "a", "down": False}),
     ]
+
+
+def test_on_release_includes_scan_vk_codes():
+    """on_release should preserve scan and vk codes in the payload."""
+
+    logger = capture.InputLogger()
+
+    class Key:
+        def __init__(self, scan, vk):
+            self.scan = scan
+            self.vk = vk
+
+    # Use known mappings from agent.wasd
+    import agent.wasd as wasd
+
+    key = Key(wasd.SCANCODES["a"], wasd.VK_CODES["a"])
+
+    with patch("time.time", return_value=0.0):
+        logger.on_release(key)
+
+    events = logger.flush()
+
+    assert events == [
+        (
+            0.0,
+            "key",
+            {
+                "key": "a",
+                "down": False,
+                "scan": wasd.SCANCODES["a"],
+                "vk": wasd.VK_CODES["a"],
+            },
+        )
+    ]

--- a/tests/test_resolve_key.py
+++ b/tests/test_resolve_key.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+# Make repository root importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import agent.wasd as wasd
+
+
+def test_resolve_key_only_scan():
+    sc = wasd.SCANCODES["w"]
+    assert wasd.resolve_key({"scan": sc}) == "w"
+
+
+def test_resolve_key_only_vk():
+    vk = wasd.VK_CODES["a"]
+    assert wasd.resolve_key({"vk": vk}) == "a"
+
+
+def test_resolve_key_key_prefix():
+    assert wasd.resolve_key("Key.space") == "space"


### PR DESCRIPTION
## Summary
- Include scan and vk codes when InputLogger records key presses/releases
- Add tests covering scan/vk capture on release
- Add standalone tests for `resolve_key` handling of scan codes, vk codes, and `Key.<name>` strings

## Testing
- `python -m pip install numpy -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aebf484ca88330a4677254b8dd83ea