### PR TITLE
Allow burst clicks to bypass rate limiting

### DIFF
--- a/agent/interaction.py
+++ b/agent/interaction.py
@@ -14,16 +14,16 @@ def _rate_limit_ok() -> bool:
         return True
     return False
 
-def click_bbox_center(bbox, region):
+def click_bbox_center(bbox, region, rate_limit: bool = True):
     x1, y1, x2, y2 = bbox
     left, top, width, height = region
     cx = int(left + (x1 + x2) / 2)
     cy = int(top + (y1 + y2) / 2)
-    if _rate_limit_ok():
+    if not rate_limit or _rate_limit_ok():
         pyautogui.moveTo(cx, cy, duration=0)
         pyautogui.click()
 
 def burst_click(bbox, region, n=3, interval=0.08):
     for _ in range(n):
-        click_bbox_center(bbox, region)
+        click_bbox_center(bbox, region, rate_limit=False)
         time.sleep(interval)

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+
+# Make repository root importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub pyautogui so interaction module can be imported without the real dependency
+pyautogui_stub = types.SimpleNamespace(moveTo=lambda *a, **k: None, click=lambda *a, **k: None)
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+
+import agent.interaction as interaction
+
+
+def test_burst_click_executes_requested_number_of_clicks(monkeypatch):
+    clicks = []
+
+    monkeypatch.setattr(interaction.pyautogui, "moveTo", lambda *a, **k: None)
+    monkeypatch.setattr(interaction.pyautogui, "click", lambda *a, **k: clicks.append(1))
+    monkeypatch.setattr(interaction, "_rate_limit_ok", lambda: False)
+    monkeypatch.setattr(interaction.time, "sleep", lambda *a, **k: None)
+
+    interaction.burst_click((0, 0, 1, 1), (0, 0, 100, 100), n=5, interval=0)
+
+    assert len(clicks) == 5


### PR DESCRIPTION
## Summary
- add `rate_limit` flag to `click_bbox_center`
- ensure `burst_click` bypasses rate limiting
- test that `burst_click` performs requested clicks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed3a926088330913101ce6b51adb7