### PR TITLE
Allow GUI to be executed as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The script saves results under `runs/detect/train` by default. Adjust epochs, im
 ### GUI
 Launch the control panel with real‑time preview and training utilities:
 ```bash
-python gui/app.py
+python -m gui.app
 ```
 
 ### Headless Agent

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,1 @@
+"""GUI package for Metin2 Vision Agent."""

--- a/gui/app.py
+++ b/gui/app.py
@@ -14,13 +14,21 @@ configuring the rotation scan used to locate objects when none are visible.
 Dependencies: PySide6, numpy, OpenCV, pyautogui, pynput, ultralytics.
 """
 
-import os
 import sys
-import threading
-import time
 from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Ensure project root on ``sys.path`` when executed as a module (``python -m``)
+# ---------------------------------------------------------------------------
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 import json
 import logging
+import os
+import threading
+import time
 
 import cv2
 import numpy as np


### PR DESCRIPTION
## Summary
- add `gui.__init__` and ensure project root is added to `sys.path`
- document launching the GUI via `python -m gui.app`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pywin32>=306)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeda9a06cc8330889ddc9306cb935a