### PR TITLE
Centralize configuration handling

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,87 +1,109 @@
-"""Agent configuration helpers.
+"""Configuration loader for the Metin2 agent.
 
-This module provides a small wrapper around the YAML configuration file used by
-the project.  It parses the teleport locations and channel list during
-initialisation and exposes helper methods allowing the user to modify these
-lists and save the configuration back to disk.
+This module exposes :func:`get_config` which loads ``config/agent.yaml``
+and merges it with a set of sane defaults.  Other modules simply import
+:func:`get_config` to obtain a dictionary with configuration values.
+Missing entries fall back to defaults so that incomplete configuration files
+never cause runtime errors.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List, Dict, Any
-
+from pathlib import Path
+from typing import Any, Dict
+import copy
 import yaml
 
+# ---------------------------------------------------------------------------
+# Default configuration used when keys are missing from the YAML file.
+# ---------------------------------------------------------------------------
+DEFAULT_CFG: Dict[str, Any] = {
+    "window": {"title_substr": "Metin2"},
+    "paths": {
+        "templates_dir": "assets/templates",
+        "model": "runs/detect/train/weights/best.pt",
+    },
+    "controls": {
+        "keys": {
+            "forward": "w",
+            "left": "a",
+            "back": "s",
+            "right": "d",
+            "rotate": "e",
+        },
+        "key_repeat_ms": 60,
+        "mouse_pause": 0.02,
+    },
+    "detector": {
+        "classes": ["metin", "boss", "potwory"],
+        "conf_thr": 0.5,
+        "iou_thr": 0.45,
+    },
+    "policy": {"deadzone_x": 0.05, "desired_box_w": 0.12},
+    "stuck": {"flow_window": 0.8, "min_flow_mag": 0.7, "rotate_ms_on_stuck": 250},
+    "scan": {
+        "period": 0.066,
+        "key": "e",
+        "sweeps": 8,
+        "sweep_ms": 250,
+        "idle_sec": 1.5,
+        "pause": 0.12,
+    },
+    "cooldowns": {"slot_min": 10},
+    "priority": ["boss", "metin", "potwory"],
+    "teleport": {
+        "slots": [],
+        "no_target_sec": 10,
+        "channel_every": 8,
+    },
+    "channels": [1, 2, 3, 4, 5, 6, 7, 8],
+    "cycle": {
+        "ch_from": 1,
+        "ch_to": 8,
+        "slots": [1, 2, 3, 4, 5, 6, 7, 8],
+        "per_spot_sec": 90,
+        "clear_sec": 6,
+    },
+}
 
-@dataclass
-class TeleportSlot:
-    """Single teleport location defined by page and slot number."""
 
-    page: str
-    slot: int
+def _deep_update(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge ``updates`` into ``base``."""
+
+    for key, val in updates.items():
+        if isinstance(val, dict):
+            base[key] = _deep_update(base.get(key, {}), val)
+        else:
+            base[key] = val
+    return base
 
 
-@dataclass
-class AgentConfig:
-    """Wrapper around the agent configuration dictionary.
+_cfg: Dict[str, Any] | None = None
 
-    Attributes
-    ----------
-    data:
-        Raw configuration dictionary used by the rest of the codebase.
-    teleport_slots:
-        List of :class:`TeleportSlot` objects parsed from ``teleport.slots``.
-    channels:
-        List of channel numbers available to the agent.
+
+def load_config(path: str | Path = "config/agent.yaml") -> Dict[str, Any]:
+    """Load configuration file and merge with defaults."""
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        data = {}
+    cfg = copy.deepcopy(DEFAULT_CFG)
+    _deep_update(cfg, data)
+    return cfg
+
+
+def get_config(path: str | Path = "config/agent.yaml") -> Dict[str, Any]:
+    """Return cached configuration dictionary.
+
+    The configuration is loaded on first use and then cached for subsequent
+    calls.  ``path`` is honoured only on the first invocation.
     """
 
-    data: Dict[str, Any]
-    teleport_slots: List[TeleportSlot] = field(default_factory=list)
-    channels: List[int] = field(default_factory=list)
+    global _cfg
+    if _cfg is None:
+        _cfg = load_config(path)
+    return _cfg
 
-    # ------------------------------------------------------------------
-    # Loading / saving
-    # ------------------------------------------------------------------
-    @classmethod
-    def load(cls, path: str = "config/agent.yaml") -> "AgentConfig":
-        """Load configuration from ``path`` and parse custom fields."""
-
-        with open(path, encoding="utf-8") as f:
-            raw = yaml.safe_load(f) or {}
-        slots = [TeleportSlot(**s) for s in raw.get("teleport", {}).get("slots", [])]
-        channels = list(raw.get("channels", []))
-        return cls(raw, slots, channels)
-
-    def save(self, path: str = "config/agent.yaml") -> None:
-        """Serialise configuration back to YAML file."""
-
-        self.data.setdefault("teleport", {})["slots"] = [s.__dict__ for s in self.teleport_slots]
-        self.data["channels"] = list(self.channels)
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.safe_dump(self.data, f, allow_unicode=True)
-
-    # ------------------------------------------------------------------
-    # Mutation helpers
-    # ------------------------------------------------------------------
-    def add_channel(self, ch: int) -> None:
-        """Add a channel number if it is not already present."""
-
-        if ch not in self.channels:
-            self.channels.append(ch)
-
-    def remove_channel(self, ch: int) -> None:
-        """Remove channel number if present."""
-
-        if ch in self.channels:
-            self.channels.remove(ch)
-
-    def add_slot(self, page: str, slot: int) -> None:
-        """Append a new teleport slot definition."""
-
-        self.teleport_slots.append(TeleportSlot(page, slot))
-
-    def remove_slot(self, page: str, slot: int) -> None:
-        """Remove a teleport slot matching ``page`` and ``slot``."""
-
-        self.teleport_slots = [s for s in self.teleport_slots if not (s.page == page and s.slot == slot)]
+__all__ = ["get_config", "load_config"]

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -1,25 +1,48 @@
 window:
   title_substr: "Metin2"
-templates_dir: "assets/templates"
+paths:
+  templates_dir: "assets/templates"
+  model: "runs/detect/train/weights/best.pt"
 controls:
-  keys: {forward: "w", left: "a", back: "s", right: "d"}
+  keys:
+    forward: "w"
+    left: "a"
+    back: "s"
+    right: "d"
+    rotate: "e"
+  key_repeat_ms: 60
+  mouse_pause: 0.02
 detector:
-  model_path: "runs/detect/train/weights/best.pt"
   classes: ["metin","boss","potwory"]
   conf_thr: 0.5
   iou_thr: 0.45
 policy:
   deadzone_x: 0.05
   desired_box_w: 0.12
-  key_repeat_ms: 60
 stuck:
   flow_window: 0.8
   min_flow_mag: 0.7
   rotate_ms_on_stuck: 250
+scan:
+  period: 0.066
+  key: "e"
+  sweeps: 8
+  sweep_ms: 250
+  idle_sec: 1.5
+  pause: 0.12
+cooldowns:
+  slot_min: 10
 priority: ["boss","metin","potwory"]
 teleport:
   slots:
     - {page: "Strona I", slot: 1}
     - {page: "Strona I", slot: 2}
-    # … kolejne wpisy
+  no_target_sec: 10
+  channel_every: 8
 channels: [1,2,3,4,5,6,7,8]
+cycle:
+  ch_from: 1
+  ch_to: 8
+  slots: [1,2,3,4,5,6,7,8]
+  per_spot_sec: 90
+  clear_sec: 6

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -129,9 +129,9 @@ def test_hunt_destroy_continuous_movement(monkeypatch):
     monkeypatch.setattr(hd, "burst_click", lambda *a, **k: None)
 
     cfg = {
-        "detector": {"model_path": "", "classes": [], "conf_thr": 0.5, "iou_thr": 0.5},
+        "paths": {"model": "", "templates_dir": ""},
+        "detector": {"classes": [], "conf_thr": 0.5, "iou_thr": 0.5},
         "policy": {"desired_box_w": 0.2, "deadzone_x": 0.1},
-        "templates_dir": "",
         "dry_run": True,
     }
 


### PR DESCRIPTION
## Summary
- add defaulted configuration loader and expose `get_config`
- move constants into `config/agent.yaml` sections (paths, scan, cooldowns, etc.)
- refactor agent modules and GUI to read settings from the shared config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aedc3350f083308b331b09df06629e