### PR TITLE
feat: ensure project root in gui app

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -18,9 +18,16 @@ import sys
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
-# Ensure project root on ``sys.path`` when executed as a module (``python -m``)
+# Ensure project root on ``sys.path`` regardless of package depth
 # ---------------------------------------------------------------------------
-ROOT_DIR = Path(__file__).resolve().parent.parent
+# Walk up the directory tree until both ``agent`` and ``recorder`` packages
+# are found.  This allows running the module with ``python -m gui.app`` even if
+# the project is nested deeper in the filesystem hierarchy.
+ROOT_DIR = Path(__file__).resolve()
+for parent in ROOT_DIR.parents:
+    if (parent / "agent").exists() and (parent / "recorder").exists():
+        ROOT_DIR = parent
+        break
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 

--- a/recorder/__init__.py
+++ b/recorder/__init__.py
@@ -1,0 +1,1 @@
+"""Recorder package providing screen capture utilities."""


### PR DESCRIPTION
## Summary
- search for project root at runtime so `agent` and `recorder` can be imported when running `python -m gui.app`
- add docstring to recorder package to guarantee module discovery

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aedd86963c8330b0c982bb4b7e6059