### PR TITLE
Add unit tests for YOLO detection and channel switching

### DIFF
--- a/tests/test_channel_switcher.py
+++ b/tests/test_channel_switcher.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import types
+import importlib
+import pytest
+
+sys.modules.pop("numpy", None)
+np = importlib.import_module("numpy")
+
+# Ensure repository root on path and stub optional dependencies
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+
+# Stub pyautogui to avoid real mouse interaction
+pyautogui_stub = types.SimpleNamespace(moveTo=lambda *a, **k: None, click=lambda *a, **k: None)
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+# Stub recorder.window_capture so ChannelSwitcher can be imported without dependencies
+recorder_pkg = types.ModuleType("recorder")
+recorder_pkg.__path__ = []
+wc_mod = types.ModuleType("recorder.window_capture")
+class WindowCapture:
+    def __init__(self, *a, **k):
+        self.region = (0, 0, 300, 300)
+    def grab(self):
+        return np.zeros((300, 300, 4), dtype=np.uint8)
+    def focus(self):
+        pass
+recorder_pkg.window_capture = wc_mod
+wc_mod.WindowCapture = WindowCapture
+sys.modules.setdefault("recorder", recorder_pkg)
+sys.modules.setdefault("recorder.window_capture", wc_mod)
+
+# Provide a minimal TemplateMatcher stub used during import; tests will patch as needed
+tm_stub = types.ModuleType("agent.template_matcher")
+class _TM:
+    def __init__(self, *a, **k):
+        pass
+    def find(self, *a, **k):
+        return None
+tm_stub.TemplateMatcher = _TM
+sys.modules.setdefault("agent.template_matcher", tm_stub)
+
+import agent.channel as channel
+
+
+class DummyWin:
+    def __init__(self):
+        self.region = (0, 0, 300, 300)
+    def grab(self):
+        return np.zeros((300, 300, 4), dtype=np.uint8)
+    def focus(self):
+        pass
+
+
+def _setup_templates(tmp_path):
+    for i in range(1, 9):
+        (tmp_path / f"ch{i}.png").touch()
+
+
+def test_switch_clicks_on_success(tmp_path, monkeypatch):
+    _setup_templates(tmp_path)
+    class TM:
+        def __init__(self, *a, **k):
+            pass
+        def find(self, frame, name, **kw):
+            return {"center": (50, 60)}
+    monkeypatch.setattr(channel, "TemplateMatcher", TM)
+    moves, clicks = [], []
+    monkeypatch.setattr(channel.pyautogui, "moveTo", lambda *a, **k: moves.append(1))
+    monkeypatch.setattr(channel.pyautogui, "click", lambda *a, **k: clicks.append(1))
+    cs = channel.ChannelSwitcher(DummyWin(), str(tmp_path), dry=False)
+    assert cs.switch(1, tries=1) is True
+    assert moves and clicks
+
+
+def test_switch_returns_false_when_not_found(tmp_path, monkeypatch):
+    _setup_templates(tmp_path)
+    class TM:
+        def __init__(self, *a, **k):
+            pass
+        def find(self, frame, name, **kw):
+            return None
+    monkeypatch.setattr(channel, "TemplateMatcher", TM)
+    moves, clicks = [], []
+    monkeypatch.setattr(channel.pyautogui, "moveTo", lambda *a, **k: moves.append(1))
+    monkeypatch.setattr(channel.pyautogui, "click", lambda *a, **k: clicks.append(1))
+    cs = channel.ChannelSwitcher(DummyWin(), str(tmp_path), dry=False)
+    assert cs.switch(1, tries=1) is False
+    assert not moves and not clicks

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import types
+import importlib
+from unittest.mock import patch
+
+sys.modules.pop("numpy", None)
+np = importlib.import_module("numpy")
+
+# Ensure repository root on path and stub optional dependencies
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+# Provide minimal cv2 stub so ``cv2.setNumThreads`` is available
+sys.modules["cv2"] = types.SimpleNamespace(setNumThreads=lambda *a, **k: None)
+
+# Provide a minimal ultralytics stub so agent.detector can be imported
+ultra_stub = types.ModuleType("ultralytics")
+class _StubYOLO:
+    def __init__(self, *a, **k):
+        pass
+    def predict(self, *a, **k):
+        return []
+ultra_stub.YOLO = _StubYOLO
+sys.modules.setdefault("ultralytics", ultra_stub)
+
+import agent.detector as detector
+
+
+class FakeTensor:
+    def __init__(self, value):
+        self.value = value
+    def cpu(self):
+        return self
+    def numpy(self):
+        return np.array(self.value)
+    def __getitem__(self, idx):
+        return FakeTensor(self.value[idx])
+    def __int__(self):
+        return int(self.value)
+
+
+class FakeBox:
+    def __init__(self, cls, xyxy, conf):
+        self.cls = FakeTensor(cls)
+        self.xyxy = FakeTensor([xyxy])
+        self.conf = FakeTensor(conf)
+
+
+class FakeResult:
+    def __init__(self):
+        self.names = {0: "metin", 1: "boss"}
+        self.boxes = [
+            FakeBox(0, [10, 20, 30, 40], 0.9),
+            FakeBox(1, [50, 60, 70, 80], 0.8),
+        ]
+
+
+def test_infer_filters_classes():
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+    with patch("agent.detector.YOLO") as MockYOLO:
+        model = MockYOLO.return_value
+        model.predict.return_value = [FakeResult()]
+        det = detector.ObjectDetector("model.pt", classes=["boss"])
+        out = det.infer(frame)
+    assert out == [{"name": "boss", "bbox": [50.0, 60.0, 70.0, 80.0], "conf": 0.8}]


### PR DESCRIPTION
## Summary
- Add `test_detector` to validate YOLO detection filtering and bbox parsing
- Add `test_channel_switcher` to verify channel switching click logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedfcc73b88330a95fe4334fd47a35