### PR TITLE
feat: add adaptive detection rate and resolution

### DIFF
--- a/agent/detector.py
+++ b/agent/detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Dict
 
+import time
 import numpy as np
 import cv2
 from ultralytics import YOLO
@@ -10,25 +11,64 @@ cv2.setNumThreads(1)
 
 
 class ObjectDetector:
-    """Lekka nakładka na Ultralytics YOLO do detekcji na klatce BGR (numpy array)."""
+    """Lekka nakładka na Ultralytics YOLO do detekcji na klatce BGR (numpy array).
 
-    def __init__(self, model_path: str, classes: list[str] | None = None,
-                 conf: float = 0.5, iou: float = 0.45, device=None):
+    Dodatkowo umożliwia ograniczenie częstotliwości detekcji oraz
+    dynamiczne skalowanie rozdzielczości wejściowej w celu redukcji
+    obciążenia CPU/GPU.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        classes: list[str] | None = None,
+        conf: float = 0.5,
+        iou: float = 0.45,
+        device=None,
+        max_fps: float | None = None,
+        dynamic_resize: bool = False,
+        min_scale: float = 0.5,
+    ):
         self.model_path = model_path
         self.model = YOLO(model_path)
         self.classes = classes
         self.conf = conf
         self.iou = iou
         self.device = device
+        # limit detekcji do ``max_fps`` razy na sekundę
+        self.max_fps = max_fps
+        self._last_infer_time = 0.0
+        self._last_result: List[Dict] = []
+        # dynamiczne skalowanie rozdzielczości
+        self.dynamic_resize = dynamic_resize
+        self.min_scale = min_scale
+        self.scale = 1.0
 
     def infer(self, frame_bgr: np.ndarray) -> List[Dict]:
+        now = time.time()
+        if self.max_fps:
+            min_interval = 1.0 / self.max_fps
+            if now - self._last_infer_time < min_interval:
+                return self._last_result
+        self._last_infer_time = now
+
+        frame_in = frame_bgr
+        if self.dynamic_resize and self.scale < 1.0:
+            h, w = frame_bgr.shape[:2]
+            new_w = max(1, int(w * self.scale))
+            new_h = max(1, int(h * self.scale))
+            frame_in = cv2.resize(frame_bgr, (new_w, new_h))
+
+        start = time.time()
         res = self.model.predict(
-            source=frame_bgr,
+            source=frame_in,
             verbose=False,
             conf=self.conf,
             iou=self.iou,
             device=self.device,
         )[0]
+        infer_time = time.time() - start
+
         out: List[Dict] = []
         names = res.names
         for box in res.boxes:
@@ -37,6 +77,12 @@ class ObjectDetector:
             if self.classes and name not in self.classes:
                 continue
             x1, y1, x2, y2 = box.xyxy[0].cpu().numpy().tolist()
+            if self.dynamic_resize and self.scale < 1.0:
+                # przeskaluj współrzędne do rozmiaru oryginalnego
+                x1 /= self.scale
+                y1 /= self.scale
+                x2 /= self.scale
+                y2 /= self.scale
             out.append(
                 {
                     "name": name,
@@ -44,4 +90,14 @@ class ObjectDetector:
                     "conf": float(box.conf.cpu().numpy()),
                 }
             )
+
+        self._last_result = out
+
+        if self.dynamic_resize:
+            target = 1.0 / self.max_fps if self.max_fps else 0.1
+            if infer_time > target and self.scale > self.min_scale:
+                self.scale = max(self.min_scale, self.scale * 0.8)
+            elif infer_time < target * 0.5 and self.scale < 1.0:
+                self.scale = min(1.0, self.scale / 0.8)
+
         return out

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -10,8 +10,11 @@ np = importlib.import_module("numpy")
 # Ensure repository root on path and stub optional dependencies
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.modules.setdefault("yaml", types.ModuleType("yaml"))
-# Provide minimal cv2 stub so ``cv2.setNumThreads`` is available
-sys.modules["cv2"] = types.SimpleNamespace(setNumThreads=lambda *a, **k: None)
+# Provide minimal cv2 stub with ``resize`` so ObjectDetector can downscale frames
+sys.modules["cv2"] = types.SimpleNamespace(
+    setNumThreads=lambda *a, **k: None,
+    resize=lambda img, size: np.zeros((size[1], size[0], img.shape[2]), dtype=img.dtype),
+)
 
 # Provide a minimal ultralytics stub so agent.detector can be imported
 ultra_stub = types.ModuleType("ultralytics")
@@ -63,3 +66,28 @@ def test_infer_filters_classes():
         det = detector.ObjectDetector("model.pt", classes=["boss"])
         out = det.infer(frame)
     assert out == [{"name": "boss", "bbox": [50.0, 60.0, 70.0, 80.0], "conf": 0.8}]
+
+
+def test_infer_rate_limited():
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+    with patch("agent.detector.YOLO") as MockYOLO:
+        model = MockYOLO.return_value
+        model.predict.return_value = [FakeResult()]
+        det = detector.ObjectDetector("model.pt", max_fps=1)
+        out1 = det.infer(frame)
+        out2 = det.infer(frame)
+    # predict should be called only once due to FPS limiting
+    assert model.predict.call_count == 1
+    assert out1 == out2
+
+
+def test_infer_resizes_when_scaled():
+    frame = np.zeros((20, 20, 3), dtype=np.uint8)
+    with patch("agent.detector.YOLO") as MockYOLO:
+        model = MockYOLO.return_value
+        model.predict.return_value = [FakeResult()]
+        det = detector.ObjectDetector("model.pt", dynamic_resize=True)
+        det.scale = 0.5
+        with patch("agent.detector.cv2.resize", wraps=detector.cv2.resize) as m_resize:
+            det.infer(frame)
+            assert m_resize.called


### PR DESCRIPTION
## Summary
- add optional max_fps and dynamic resolution scaling to ObjectDetector
- extend detector unit tests for rate limiting and resize behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee25690a88330854a1fa5f20b5f5d