### PR TITLE
Add foreground checks before sending input

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -42,7 +42,12 @@ class ChannelSwitcher:
             if m:
                 L, T, _, _ = self.win.region
                 cx, cy = m["center"]
-                self.win.focus()
+
+                if not self.win.is_foreground():
+                    self.win.focus()
+                    if not self.win.is_foreground():
+                        return False
+
                 if not self.dry:
                     pyautogui.moveTo(L + cx, T + cy, duration=0.05)
                     pyautogui.click()

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -84,4 +84,4 @@ class HuntDestroy:
             if hasattr(self.keys, "dry") and self.keys.dry:
                 return
             logger.debug("Atakuję cel")
-            burst_click(tgt["bbox"], (left, top, w, h))
+            burst_click(tgt["bbox"], (left, top, w, h), win=self.win)

--- a/agent/interaction.py
+++ b/agent/interaction.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 import time
 import pyautogui
 
+try:  # avoid circular import during tests
+    from recorder.window_capture import WindowCapture
+except Exception:  # pragma: no cover - optional dependency in tests
+    WindowCapture = None
+
 _LAST_CLICK_TS = 0.0
 _MAX_CPS = 5  # klików na sekundę (limit bezpieczeństwa)
 
@@ -14,16 +19,45 @@ def _rate_limit_ok() -> bool:
         return True
     return False
 
-def click_bbox_center(bbox, region, rate_limit: bool = True):
+def click_bbox_center(bbox, region, rate_limit: bool = True, win: WindowCapture | None = None) -> bool:
+    """Kliknij w środek ``bbox`` w obrębie ``region`` jeśli okno jest aktywne.
+
+    Parameters
+    ----------
+    bbox, region: tuple
+        Współrzędne celu i obszaru w jakim się znajduje.
+    rate_limit: bool
+        Czy stosować ograniczenie liczby klików na sekundę.
+    win: WindowCapture | None
+        Opcjonalna instancja okna pozwalająca sprawdzić fokus.
+
+    Returns
+    -------
+    bool
+        ``True`` jeśli kliknięcie zostało wykonane.
+    """
+
     x1, y1, x2, y2 = bbox
     left, top, width, height = region
     cx = int(left + (x1 + x2) / 2)
     cy = int(top + (y1 + y2) / 2)
+
+    if win is not None:
+        if not win.is_foreground():
+            win.focus()
+            if not win.is_foreground():
+                return False
+
     if not rate_limit or _rate_limit_ok():
         pyautogui.moveTo(cx, cy, duration=0)
         pyautogui.click()
+        return True
+    return False
 
-def burst_click(bbox, region, n=3, interval=0.08):
+
+def burst_click(bbox, region, n=3, interval=0.08, win: WindowCapture | None = None):
+    """Seria kliknięć w ``bbox`` z zachowaniem bezpieczeństwa fokusu."""
     for _ in range(n):
-        click_bbox_center(bbox, region, rate_limit=False)
+        if not click_bbox_center(bbox, region, rate_limit=False, win=win):
+            break
         time.sleep(interval)

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -61,11 +61,18 @@ class Teleporter:
     def _safe_click(self, x: int, y: int) -> None:
         if self.dry:
             return
+        if not self.win.is_foreground():
+            self.win.focus()
+            if not self.win.is_foreground():
+                return
         pyautogui.moveTo(x, y, duration=self.click_duration)
         pyautogui.click()
 
     def open_panel(self) -> None:
-        self.win.focus()
+        if not self.win.is_foreground():
+            self.win.focus()
+            if not self.win.is_foreground():
+                return
         if not self.dry:
             self.keys.press("ctrl")
             self.keys.press("x")

--- a/tests/test_channel_switcher.py
+++ b/tests/test_channel_switcher.py
@@ -51,6 +51,8 @@ class DummyWin:
         return np.zeros((300, 300, 4), dtype=np.uint8)
     def focus(self):
         pass
+    def is_foreground(self):
+        return True
 
 
 def _setup_templates(tmp_path):


### PR DESCRIPTION
## Summary
- Guard keyboard and mouse actions with foreground checks to avoid stealing control
- Add window parameter to interaction helpers and update hunting logic to use it
- Update channel switching, teleport, and tests for safe focus handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee4674d348330a21748e2d4a5ad81