### PR TITLE
Add channel settle timing and scan cycle when clear

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -52,6 +52,7 @@ DEFAULT_CFG: Dict[str, Any] = {
     },
     "cooldowns": {"slot_min": 10},
     "priority": ["boss", "metin", "potwory"],
+    "channel": {"settle_sec": 5.0, "timeout_per_ch": 5.0},
     "teleport": {
         "slots": [],
         "no_target_sec": 10,

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -40,6 +40,9 @@ teleport:
   no_target_sec: 10
   channel_every: 8
 channels: [1,2,3,4,5,6,7,8]
+channel:
+  settle_sec: 5.0
+  timeout_per_ch: 5.0
 cycle:
   ch_from: 1
   ch_to: 8

--- a/tests/test_channel_switcher.py
+++ b/tests/test_channel_switcher.py
@@ -152,5 +152,10 @@ def test_cycle_until_target_seen(tmp_path, monkeypatch):
         calls["n"] += 1
         return calls["n"] >= 3
 
-    assert cs.cycle_until_target_seen(check_fn, timeout=5, post_wait=0) is True
+    assert (
+        cs.cycle_until_target_seen(
+            check_fn, settle=0, timeout_per_ch=0, max_rounds=1
+        )
+        is True
+    )
     assert switched == [2, 3]


### PR DESCRIPTION
## Summary
- read channel settle and per-channel check time from config
- wait configurable settle time on channel switch
- cycle through channels once before considering a spot clear

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afeb0ee49c8330856472201c4cc13e