### PR TITLE
Include channel timing in GUI configuration

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -511,6 +511,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 "pause": 0.12,
             },
             "cooldowns": {"slot_min": int(self.cooldown_spin.value())},
+            "channel": {"settle_sec": 5.0, "timeout_per_ch": 2.5},
             "ui": {"scale": float(self.scale_spin.value())},
         }
         return cfg


### PR DESCRIPTION
## Summary
- Add `channel` configuration in GUI build_cfg with `settle_sec` and `timeout_per_ch`
- Ensure saved configurations include channel timing so `CycleFarm` can read them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aff266fffc8330b6e8e3b4da18188f