### PR TITLE
Integrate pydirectinput for keyboard events

### DIFF
--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -6,6 +6,11 @@ import threading
 import time
 from ctypes import wintypes
 
+try:  # pragma: no cover - optional dependency
+    import pydirectinput
+except Exception:  # pragma: no cover - gracefully handle missing module
+    pydirectinput = None
+
 # ---------------------------------------------------------------------------
 # ``SendInput`` helpers working with scan codes
 # ---------------------------------------------------------------------------
@@ -47,6 +52,14 @@ else:
 
 def _send_scan(scan: int, keyup: bool = False, extended: bool = False) -> None:
     """Send a single keyboard event using the provided scan code."""
+
+    key = REVERSE_SCANCODES.get(scan)
+    if pydirectinput is not None and key:
+        if keyup:
+            pydirectinput.keyUp(key)
+        else:
+            pydirectinput.keyDown(key)
+        return
 
     if _user32 is None:
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ torchvision==0.23.0
 Pillow==11.3.0
 pynput==1.8.1
 keyboard==0.13.5
+pydirectinput==1.0.4
 pywin32>=306


### PR DESCRIPTION
## Summary
- use pydirectinput to send key presses when available
- declare pydirectinput dependency

## Testing
- `python -m isort agent/wasd.py`
- `python -m black agent/wasd.py`
- `python -m flake8 agent/wasd.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00b8f43b48330b35e184da20f9245