### PR TITLE
Disable pydirectinput pause for faster key sending

### DIFF
--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -57,7 +57,10 @@ def _send_scan(scan: int, keyup: bool = False, extended: bool = False) -> None:
     if pydirectinput is not None and key:
         func = pydirectinput.keyUp if keyup else pydirectinput.keyDown
         try:
-            result = func(key)
+            # ``pydirectinput`` adds a small pause between calls by default
+            # which would slow down rapid key sequences.  Pass ``_pause=False``
+            # to disable this behavior and send the event immediately.
+            result = func(key, _pause=False)
             if result is not False:
                 return
             logger.warning(

--- a/tests/test_send_scan_fallback.py
+++ b/tests/test_send_scan_fallback.py
@@ -24,7 +24,7 @@ def test_send_scan_falls_back_on_false_return(caplog):
     with patch.object(wasd, "pydirectinput", fake_pd), patch.object(wasd, "_user32", user32):
         with caplog.at_level(logging.WARNING):
             wasd._send_scan(scan)
-    fake_pd.keyDown.assert_called_once_with("w")
+    fake_pd.keyDown.assert_called_once_with("w", _pause=False)
     user32.SendInput.assert_called_once()
     assert any("pydirectinput.keyDown" in r.message for r in caplog.records)
 
@@ -38,7 +38,7 @@ def test_send_scan_falls_back_on_exception(caplog):
     with patch.object(wasd, "pydirectinput", fake_pd), patch.object(wasd, "_user32", user32):
         with caplog.at_level(logging.WARNING):
             wasd._send_scan(scan, keyup=True)
-    fake_pd.keyUp.assert_called_once_with("w")
+    fake_pd.keyUp.assert_called_once_with("w", _pause=False)
     user32.SendInput.assert_called_once()
     assert any("pydirectinput.keyUp" in r.message for r in caplog.records)
 

--- a/tests/test_send_scan_no_pause.py
+++ b/tests/test_send_scan_no_pause.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import time
+import types
+from unittest.mock import patch
+
+# Make repository root importable and stub optional dependency
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+
+import agent.wasd as wasd
+
+
+def test_send_scan_no_pause_between_events():
+    calls = []
+
+    def keyDown(key, _pause=True):
+        if _pause:
+            time.sleep(0.1)
+        calls.append(time.perf_counter())
+
+    def keyUp(key, _pause=True):
+        if _pause:
+            time.sleep(0.1)
+        calls.append(time.perf_counter())
+
+    fake_pd = types.SimpleNamespace(keyDown=keyDown, keyUp=keyUp)
+    scan = wasd.SCANCODES["w"]
+    with patch.object(wasd, "pydirectinput", fake_pd):
+        wasd._send_scan(scan)
+        wasd._send_scan(scan, keyup=True)
+    assert calls[1] - calls[0] < 0.05


### PR DESCRIPTION
## Summary
- disable pydirectinput's default pause when sending scan codes
- cover key event timing with new test and adjust existing fallback tests

## Testing
- `pytest tests/test_send_scan_no_pause.py tests/test_send_scan_fallback.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b027dca8088330ad2a5b59390656dc