### PR TITLE
Stop moving before attacking when target is near

### DIFF
--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -9,7 +9,7 @@ from . import get_config
 from .avoid import CollisionAvoid
 from .channel import ChannelSwitcher
 from .detector import ObjectDetector
-from .interaction import burst_click
+from .interaction import click_bbox_center
 from .movement import MovementController
 from .search import SearchManager
 from .targets import pick_target
@@ -77,12 +77,18 @@ class HuntDestroy:
         else:
             self.search.update_last_target()
 
-        bw = self.movement.move(tgt, steer, (W, H))
-        self._last_tgt = tgt
+        bw = None
+        if tgt:
+            x1, y1, x2, y2 = tgt["bbox"]
+            bw = (x2 - x1) / W
 
         if tgt and bw is not None and bw >= self.desired_w * 0.9:
+            self.keys.release_all()
             left, top, w, h = self.win.region
             if hasattr(self.keys, "dry") and self.keys.dry:
                 return
             logger.debug("Atakuję cel")
-            burst_click(tgt["bbox"], (left, top, w, h), win=self.win)
+            click_bbox_center(tgt["bbox"], (left, top, w, h), win=self.win)
+        else:
+            self.movement.move(tgt, steer, (W, H))
+        self._last_tgt = tgt

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -136,7 +136,7 @@ def test_hunt_destroy_continuous_movement(monkeypatch):
     monkeypatch.setattr(hd, "CollisionAvoid", lambda: _DummyAvoid())
     monkeypatch.setattr(hd, "KeyHold", _StubKeyHold)
     monkeypatch.setattr(hd, "pick_target", _pick_target)
-    monkeypatch.setattr(hd, "burst_click", lambda *a, **k: None)
+    monkeypatch.setattr(hd, "click_bbox_center", lambda *a, **k: None)
 
     cfg = {
         "paths": {"model": "", "templates_dir": ""},


### PR DESCRIPTION
## Summary
- Compute target width before moving and attack if within range
- Halt all movement keys and click target center when close
- Update tests to reflect click helper change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b037cac97483309723a9803acc89b7