### PR TITLE
Pass keys to ChannelSwitcher

### DIFF
--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -35,7 +35,9 @@ class HuntDestroy:
         self.keys = KeyHold(dry=dry, active_fn=getattr(self.win, "is_foreground", None))
         tdir = cfg["paths"]["templates_dir"]
         self.teleporter = Teleporter(self.win, tdir, use_ocr=True, dry=dry, cfg=cfg)
-        self.channel_switcher = ChannelSwitcher(self.win, tdir, dry=dry)
+        self.channel_switcher = ChannelSwitcher(
+            self.win, tdir, dry=dry, keys=self.keys
+        )
         self.desired_w = cfg["policy"].get("desired_box_w", 0.12)
         self.deadzone = cfg["policy"].get("deadzone_x", 0.05)
         self.priority = cfg.get("priority", ["boss", "metin", "potwory"])


### PR DESCRIPTION
## Summary
- Pass KeyHold instance to ChannelSwitcher so channel switching can use keyboard shortcuts when necessary.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0396f808c8330ac97b3aaf3340a35