### PR TITLE
Add spin search when no targets

### DIFF
--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -117,6 +117,25 @@ class _DummyAvoid:
         return None
 
 
+class _EmptyDetector:
+    def __init__(self, *a, **k):
+        pass
+
+    def infer(self, frame):
+        return []
+
+
+class _StubSearch:
+    def __init__(self, *a, **k):
+        self.calls = 0
+
+    def handle_no_target(self):
+        self.calls += 1
+
+    def update_last_target(self):
+        pass
+
+
 class _DummyWin:
     region = (0, 0, 100, 100)
 
@@ -158,3 +177,33 @@ def test_hunt_destroy_continuous_movement(monkeypatch):
     assert agent.keys.pressed.count("d") == 1
     assert agent.keys.pressed.count("a") == 1
     assert agent.keys.released == ["d"]
+
+
+def test_spin_no_target(monkeypatch):
+    monkeypatch.setattr(hd, "ObjectDetector", _EmptyDetector)
+    monkeypatch.setattr(hd, "CollisionAvoid", lambda: _DummyAvoid())
+    monkeypatch.setattr(hd, "KeyHold", _StubKeyHold)
+    monkeypatch.setattr(hd, "SearchManager", _StubSearch)
+    monkeypatch.setattr(hd, "pick_target", lambda *a, **k: None)
+    cfg = {
+        "paths": {"model": "", "templates_dir": ""},
+        "detector": {"classes": [], "conf_thr": 0.5, "iou_thr": 0.5},
+        "policy": {"desired_box_w": 0.2, "deadzone_x": 0.1},
+        "dry_run": True,
+    }
+    agent = hd.HuntDestroy(cfg, _DummyWin())
+    times = iter([0, 3, 4.1])
+    monkeypatch.setattr(hd.time, "time", lambda: next(times))
+
+    agent.step()
+    assert agent.keys.down == {"a"}
+    assert agent.search.calls == 0
+
+    agent.step()
+    assert agent.keys.down == {"a"}
+    assert agent.search.calls == 0
+
+    agent.step()
+    assert agent.keys.down == set()
+    assert agent.search.calls == 1
+    assert agent._spin_dir == "d"


### PR DESCRIPTION
## Summary
- spin in alternating directions when no target is detected
- delay search fallback until a full spin completes
- test spin-and-search logic when no targets

## Testing
- `make lint` *(fails: flake8: pydirectinput/__init__.py:296:8: E714 ...)*
- `flake8 agent/hunt_destroy.py tests/test_hunt_destroy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b039f57db08330a22b4d8b75180c3b