### PR TITLE
Guard teleport until spin completes

### DIFF
--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -76,6 +76,7 @@ class HuntDestroy:
         if tgt is None:
             logger.debug("Brak celu w zasięgu")
             now = time.time()
+            spin_done = False
             if self._spin_start is None:
                 self._spin_start = now
                 self.keys.press(self._spin_dir)
@@ -83,7 +84,9 @@ class HuntDestroy:
                 self.keys.release(self._spin_dir)
                 self._spin_start = None
                 self._spin_dir = "d" if self._spin_dir == "a" else "a"
-                self.search.handle_no_target()
+                spin_done = True
+            if spin_done:
+                self.search.handle_no_target(spin_done)
             self._last_tgt = None
             return
 

--- a/agent/search.py
+++ b/agent/search.py
@@ -37,8 +37,17 @@ class SearchManager:
     def update_last_target(self) -> None:
         self.last_target_time = time.time()
 
-    def handle_no_target(self) -> None:
-        """Teleport and optionally change channel when no target for a while."""
+    def handle_no_target(self, spin_done: bool) -> None:
+        """Teleport and optionally change channel when no target for a while.
+
+        Parameters
+        ----------
+        spin_done: bool
+            Whether a full rotation search was completed. If ``False`` the
+            method returns immediately without performing any action.
+        """
+        if not spin_done:
+            return
         now = time.time()
         if now - self.last_target_time <= self.no_target_sec:
             return

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -129,7 +129,7 @@ class _StubSearch:
     def __init__(self, *a, **k):
         self.calls = 0
 
-    def handle_no_target(self):
+    def handle_no_target(self, spin_done):
         self.calls += 1
 
     def update_last_target(self):


### PR DESCRIPTION
## Summary
- Add `spin_done` flag to SearchManager.handle_no_target to skip teleport/channel switch until a rotation search finishes
- Use `spin_done` in HuntDestroy.step to teleport only after an unsuccessful spin
- Adapt tests to new SearchManager API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03b22c6108330924f96f2221cbc9e