### PR TITLE
feat: add diagonal movement via direction vector

### DIFF
--- a/agent/movement.py
+++ b/agent/movement.py
@@ -49,12 +49,18 @@ class MovementController:
             x1, y1, x2, y2 = tgt["bbox"]
             cx = (x1 + x2) / 2 / W
             bw = (x2 - x1) / W
-            if abs(cx - 0.5) > self.deadzone:
-                desired.add("d" if cx > 0.5 else "a")
-            if bw < self.desired_w * 0.95:
+            dx = cx - 0.5
+            dy = self.desired_w - bw
+
+            if dy > 0:
                 desired.add("w")
-            elif bw > self.desired_w * 1.25:
+            elif dy < 0:
                 desired.add("s")
+
+            if dx > self.deadzone:
+                desired.add("d")
+            elif dx < -self.deadzone:
+                desired.add("a")
 
         for k in self.keys.down - desired:
             self.keys.release(k)

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -1,0 +1,28 @@
+import pytest
+
+from agent.movement import MovementController
+from agent.wasd import KeyHold
+
+
+def make_tgt(x1, x2, W=100, H=100):
+    return {"bbox": (x1, 0, x2, H)}
+
+
+def test_move_forward_right_diagonal():
+    keys = KeyHold(dry=True)
+    mc = MovementController(keys, desired_w=0.3, deadzone=0.05)
+    tgt = make_tgt(60, 80)
+    bw = mc.move(tgt, None, (100, 100))
+    assert bw == pytest.approx(0.2)
+    assert keys.down == {"w", "d"}
+    keys.stop()
+
+
+def test_move_backward_left_diagonal():
+    keys = KeyHold(dry=True)
+    mc = MovementController(keys, desired_w=0.3, deadzone=0.05)
+    tgt = make_tgt(10, 50)
+    bw = mc.move(tgt, None, (100, 100))
+    assert bw == pytest.approx(0.4)
+    assert keys.down == {"s", "a"}
+    keys.stop()


### PR DESCRIPTION
## Summary
- compute direction vector to target for movement keys
- add tests for diagonal key combinations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b03c743d388330a80f79b818ccea1e