### PR TITLE
Add teleport position runner and fix hunt scanning logic

### DIFF
--- a/agent/teleport_config.py
+++ b/agent/teleport_config.py
@@ -1,10 +1,16 @@
-"""Teleport configuration loader."""
+"""Teleport configuration loader and helpers."""
 
 from __future__ import annotations
 
 import types
+import time
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Callable
+
+try:  # pyautogui is optional during tests
+    import pyautogui
+except Exception:  # pragma: no cover - provide a tiny stub
+    pyautogui = types.SimpleNamespace(click=lambda *a, **k: None, press=lambda *a, **k: None)
 
 try:
     import yaml
@@ -33,4 +39,46 @@ positions_by_channel: Dict[int, List[Tuple[int, int]]] = _cfg.get(
 )
 channel_buttons: Dict[int, Tuple[int, int]] = _cfg.get("channel_buttons", {})
 
-__all__ = ["positions_by_channel", "channel_buttons", "load_teleport_config"]
+def open_panel() -> None:  # pragma: no cover - provided by the game
+    """Open the in‑game teleport panel.
+
+    The actual implementation is expected to be supplied by the runtime
+    environment.  A stub is provided so tests can monkeypatch it.
+    """
+
+
+def run_positions(
+    channel: int,
+    *,
+    delay: float = 1.0,
+    close_panel: Callable[[], None] | None = None,
+) -> None:
+    """Run all configured positions for ``channel``.
+
+    The teleport panel is opened once via :func:`open_panel`.  For each of the
+    eight stored positions the function performs a click, sends the interaction
+    key ``E`` and waits ``delay`` seconds for in‑game actions to complete.  When
+    ``close_panel`` is provided it is invoked after each position which allows
+    the caller to close the panel between teleports if necessary.
+    """
+
+    positions = positions_by_channel.get(channel)
+    if not positions:
+        return
+
+    open_panel()
+    for x, y in positions:
+        pyautogui.click(x, y)
+        pyautogui.press("e")
+        time.sleep(delay)
+        if close_panel:
+            close_panel()
+
+
+__all__ = [
+    "positions_by_channel",
+    "channel_buttons",
+    "load_teleport_config",
+    "open_panel",
+    "run_positions",
+]


### PR DESCRIPTION
## Summary
- add `run_positions` helper to click configured teleport points
- fix HuntDestroy to import `time` and spin with default key when no target

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13b319edc833086e8bb1769ee5447