### PR TITLE
Add channel switching helper and loop

### DIFF
--- a/agent/teleport_config.py
+++ b/agent/teleport_config.py
@@ -75,10 +75,30 @@ def run_positions(
             close_panel()
 
 
+def change_channel(target_ch: int, *, delay: float = 5.0) -> None:
+    """Click the button for ``target_ch`` and wait for a channel switch."""
+
+    coords = channel_buttons.get(target_ch)
+    if not coords:
+        return
+    x, y = coords
+    pyautogui.click(x, y)
+    time.sleep(delay)
+
+
+def main() -> None:  # pragma: no cover - helper script
+    for ch in [1, 2, 3, 4]:
+        run_positions(ch)
+        if ch < 4:
+            change_channel(ch + 1)
+
+
 __all__ = [
     "positions_by_channel",
     "channel_buttons",
     "load_teleport_config",
     "open_panel",
     "run_positions",
+    "change_channel",
+    "main",
 ]

--- a/tests/test_teleport_config.py
+++ b/tests/test_teleport_config.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import types
+
+pyautogui_stub = types.ModuleType("pyautogui")
+pyautogui_stub.click = lambda *a, **k: None
+pyautogui_stub.press = lambda *a, **k: None
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda f: {}
+sys.modules["yaml"] = yaml_stub
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import agent.teleport_config as tc
+
+
+def test_change_channel(monkeypatch):
+    calls = []
+    monkeypatch.setattr(tc, "channel_buttons", {2: (10, 20)})
+    monkeypatch.setattr(tc.pyautogui, "click", lambda x, y: calls.append((x, y)))
+    monkeypatch.setattr(tc.time, "sleep", lambda s: calls.append(s))
+    tc.change_channel(2)
+    assert calls == [(10, 20), 5.0]
+
+
+def test_main(monkeypatch):
+    run_calls = []
+    change_calls = []
+    monkeypatch.setattr(tc, "run_positions", lambda ch: run_calls.append(ch))
+    monkeypatch.setattr(tc, "change_channel", lambda ch: change_calls.append(ch))
+    tc.main()
+    assert run_calls == [1, 2, 3, 4]
+    assert change_calls == [2, 3, 4]


### PR DESCRIPTION
## Summary
- Add `change_channel` to click channel buttons and wait for the game to switch channels
- Provide a helper `main` that cycles through channels 1–4, running all teleport positions and switching channels
- Cover channel switching and main loop with dedicated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13d1966cc83308cd54f269fb514f7