### PR TITLE
feat: add configurable teleport delays

### DIFF
--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -53,6 +53,17 @@ class WasdVisionAgent:
         if not self.win.locate(timeout=5):
             raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
         self.hd = HuntDestroy(self.cfg, self.win)
-        while True:
-            self.hd.step()
-            time.sleep(self.period)
+        try:
+            while True:
+                self.hd.step()
+                time.sleep(self.period)
+        except KeyboardInterrupt:
+            if self.hd:
+                try:
+                    self.hd.teleporter.close_panel()
+                except Exception:
+                    pass
+                try:
+                    self.hd.keys.release_all()
+                except Exception:
+                    pass

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -155,10 +155,16 @@ class Teleporter:
                 except Exception:
                     found = None
 
-            if found:
-                return True
+        if found:
+            return True
 
         raise RuntimeError("Teleport panel not detected")
+
+    def close_panel(self) -> None:
+        """Close the teleport panel if it is open."""
+        if self.dry:
+            return
+        pyautogui.press("esc")
 
     def go_page(self, page_label: str, thresh: float | None = None) -> bool:
         token = page_label.split()[-1].upper().replace(" ", "_")

--- a/agent/teleport_config.py
+++ b/agent/teleport_config.py
@@ -33,6 +33,11 @@ def load_teleport_config(path: str | Path = "config/teleport.yaml") -> Dict[str,
 
 _cfg = load_teleport_config()
 
+# Delays configurable via ``config/teleport.yaml`` with sane defaults
+DELAY_AFTER_PANEL: float = float(_cfg.get("delay_after_panel", 0.5))
+DELAY_AFTER_TELEPORT: float = float(_cfg.get("delay_after_teleport", 1.0))
+DELAY_AFTER_CHANNEL: float = float(_cfg.get("delay_after_channel", 5.0))
+
 # Public mappings with fallback to empty structures
 positions_by_channel: Dict[int, List[Tuple[int, int]]] = _cfg.get(
     "positions_by_channel", {}
@@ -50,7 +55,7 @@ def open_panel() -> None:  # pragma: no cover - provided by the game
 def run_positions(
     channel: int,
     *,
-    delay: float = 1.0,
+    delay: float = DELAY_AFTER_TELEPORT,
     close_panel: Callable[[], None] | None = None,
 ) -> None:
     """Run all configured positions for ``channel``.
@@ -67,6 +72,7 @@ def run_positions(
         return
 
     open_panel()
+    time.sleep(DELAY_AFTER_PANEL)
     for x, y in positions:
         pyautogui.click(x, y)
         pyautogui.press("e")
@@ -75,7 +81,7 @@ def run_positions(
             close_panel()
 
 
-def change_channel(target_ch: int, *, delay: float = 5.0) -> None:
+def change_channel(target_ch: int, *, delay: float = DELAY_AFTER_CHANNEL) -> None:
     """Click the button for ``target_ch`` and wait for a channel switch."""
 
     coords = channel_buttons.get(target_ch)
@@ -96,6 +102,9 @@ def main() -> None:  # pragma: no cover - helper script
 __all__ = [
     "positions_by_channel",
     "channel_buttons",
+    "DELAY_AFTER_PANEL",
+    "DELAY_AFTER_TELEPORT",
+    "DELAY_AFTER_CHANNEL",
     "load_teleport_config",
     "open_panel",
     "run_positions",

--- a/config/teleport.yaml
+++ b/config/teleport.yaml
@@ -1,3 +1,6 @@
+delay_after_panel: 0.5
+delay_after_teleport: 1.0
+delay_after_channel: 5.0
 positions_by_channel:
   1:
     - [0, 0]


### PR DESCRIPTION
## Summary
- make teleport panel/channel wait times configurable
- close teleport panel and release keys on Ctrl+C

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13e2b16d48330b2e308291999a295