### PR TITLE
Handle empty screen grabs safely

### DIFF
--- a/agent/avoid.py
+++ b/agent/avoid.py
@@ -17,6 +17,8 @@ class CollisionAvoid:
         self.near_ratio = near_ratio
 
     def steer(self, frame_bgr):
+        if frame_bgr is None or frame_bgr.size == 0:
+            return None
         gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
         H, W = gray.shape
         x0 = int(W * self.band[0])

--- a/agent/template_matcher.py
+++ b/agent/template_matcher.py
@@ -32,10 +32,14 @@ class TemplateMatcher:
         if roi is not None:
             x, y, w, h = roi
             crop = frame_bgr[y : y + h, x : x + w]
+            if crop.size == 0:
+                raise ValueError(f"Invalid ROI {roi}: empty crop")
         else:
             x = y = 0
             h, w = frame_bgr.shape[:2]
             crop = frame_bgr
+            if crop.size == 0:
+                raise ValueError("Empty frame for template matching")
         gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
         return gray, x, y
 

--- a/gui/app.py
+++ b/gui/app.py
@@ -853,6 +853,11 @@ class MainWindow(QtWidgets.QMainWindow):
                     hd.step()
                     time.sleep(period)
                 self.set_status("Zakończono 'Teleportuj i poluj'.")
+            except RuntimeError as exc:
+                self.set_status(
+                    f"Błąd przechwytywania ekranu: {exc}. "
+                    "Czy okno gry jest poza ekranem lub zminimalizowane?"
+                )
             except Exception as exc:
                 self.set_status(f"Błąd teleport+poluj: {exc}")
             finally:

--- a/recorder/window_capture.py
+++ b/recorder/window_capture.py
@@ -93,7 +93,16 @@ class WindowCapture:
         """Zwraca mss.base.ScreenShot (BGRA)."""
         if self.region is None:
             self.update_region()
-        left, top, width, height = self.region
-        return self.sct.grab(
-            {"left": left, "top": top, "width": width, "height": height}
-        )
+        def _grab():
+            left, top, width, height = self.region
+            return self.sct.grab(
+                {"left": left, "top": top, "width": width, "height": height}
+            )
+
+        img = _grab()
+        if getattr(img, "width", 0) == 0 or getattr(img, "height", 0) == 0:
+            self.update_region()
+            img = _grab()
+            if getattr(img, "width", 0) == 0 or getattr(img, "height", 0) == 0:
+                raise RuntimeError("WindowCapture.grab captured empty image (zero width/height)")
+        return img


### PR DESCRIPTION
## Summary
- Guard against zero-sized screenshots in `WindowCapture.grab`
- Skip collision steering when frame is empty
- Validate template matcher ROI before conversion
- Surface capture failures with user-friendly error message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b155a5288c8330840b7e77ce57497c