### PR TITLE
Add context management to WindowCapture and ensure cleanup

### DIFF
--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -90,6 +90,10 @@ class CycleFarm:
             self.keys.stop()
         except Exception:
             pass
+        try:
+            self.win.close()
+        except Exception:
+            pass
 
     # ---- detekcje ----
     def _any_target_seen(self) -> bool:
@@ -196,4 +200,5 @@ class CycleFarm:
                 self.cooldown[key] = time.time()
 
         # zakończ po przejściu całego cyklu
+        self.win.close()
         return

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -50,10 +50,10 @@ class WasdVisionAgent:
         self.cfg.setdefault("teleport", {})["slots"] = [s.__dict__ for s in slots]
 
     def run(self):
-        if not self.win.locate(timeout=5):
-            raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
-        self.hd = HuntDestroy(self.cfg, self.win)
         try:
+            if not self.win.locate(timeout=5):
+                raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
+            self.hd = HuntDestroy(self.cfg, self.win)
             while True:
                 self.hd.step()
                 time.sleep(self.period)
@@ -67,3 +67,5 @@ class WasdVisionAgent:
                     self.hd.keys.release_all()
                 except Exception:
                     pass
+        finally:
+            self.win.close()

--- a/recorder/window_capture.py
+++ b/recorder/window_capture.py
@@ -18,6 +18,21 @@ class WindowCapture:
         self.region = None  # (left, top, width, height)
         self.sct = mss.mss()
 
+    def close(self) -> None:
+        """Release underlying screenshot resources."""
+        try:
+            self.sct.close()
+        except Exception:
+            pass
+
+    # -----------------------------------------------------
+    # Context manager API
+    def __enter__(self) -> "WindowCapture":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
     def locate(self, timeout: float | None = None) -> bool:
         """Znajdź okno po fragmencie tytułu i ustaw region.
 

--- a/tests/test_window_capture.py
+++ b/tests/test_window_capture.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import types
+
+# Ensure repository root is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Remove any stubs that other tests might have installed
+sys.modules.pop("recorder", None)
+sys.modules.pop("recorder.window_capture", None)
+
+
+class DummySct:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    def grab(self, region):
+        # minimal object with width/height attributes
+        return types.SimpleNamespace(width=1, height=1)
+
+
+# Stub external dependencies used by WindowCapture
+sys.modules.setdefault("pygetwindow", types.SimpleNamespace(getAllWindows=lambda: []))
+sys.modules.setdefault("win32con", types.SimpleNamespace())
+sys.modules.setdefault("win32gui", types.SimpleNamespace())
+sys.modules["mss"] = types.SimpleNamespace(mss=lambda: DummySct())
+
+import recorder.window_capture as wc
+
+
+def test_close_calls_underlying_close():
+    cap = wc.WindowCapture("foo")
+    assert isinstance(cap.sct, DummySct)
+    cap.close()
+    assert cap.sct.closed
+
+
+def test_context_manager_closes():
+    with wc.WindowCapture("foo") as cap:
+        assert isinstance(cap.sct, DummySct)
+    assert cap.sct.closed

--- a/tools/capture_template.py
+++ b/tools/capture_template.py
@@ -23,10 +23,10 @@ def main() -> None:
     out.mkdir(parents=True, exist_ok=True)
 
     try:
-        wc = WindowCapture("Metin2")  # fragment tytułu
-        if not wc.locate(timeout=5):
-            raise RuntimeError("Nie znaleziono okna")
-        frame = np.array(wc.grab())[:, :, :3]
+        with WindowCapture("Metin2") as wc:  # fragment tytułu
+            if not wc.locate(timeout=5):
+                raise RuntimeError("Nie znaleziono okna")
+            frame = np.array(wc.grab())[:, :, :3]
 
         # ustaw ROI ręcznie na start
         x, y, w, h = 1000, 80, 90, 30


### PR DESCRIPTION
## Summary
- add `close`, `__enter__`, and `__exit__` methods to `WindowCapture`
- update agents, GUI and tools to close captures or use context managers
- add unit tests covering WindowCapture resource cleanup

## Testing
- `flake8 agent/infer_wasd.py agent/infer_kbd.py agent/cycle.py gui/app.py recorder/window_capture.py tools/capture_template.py tests/test_window_capture.py` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b15b4b6fa08330a10645044f87324a