### PR TITLE
Add ResNet weights support and docstrings for policies

### DIFF
--- a/agent/infer_kbd.py
+++ b/agent/infer_kbd.py
@@ -5,6 +5,7 @@ import time
 import cv2
 import numpy as np
 import torch
+import torchvision.models as models
 
 from recorder.window_capture import WindowCapture
 
@@ -23,7 +24,7 @@ class KbdVisionAgent:
             fps=15,
             min_mag=cfg.get("stuck", {}).get("min_flow_mag", 0.7),
         )
-        self.net = KbdPolicy()
+        self.net = KbdPolicy(weights=models.ResNet18_Weights.IMAGENET1K_V1)
         self.net.load_state_dict(
             torch.load("checkpoints/kbd_policy.pt", map_location="cpu")
         )

--- a/agent/model.py
+++ b/agent/model.py
@@ -1,12 +1,35 @@
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 import torchvision.models as models
 
 
 class ClickPolicy(nn.Module):
-    def __init__(self):
+    """Predicts click location and probability from an RGB screenshot.
+
+    The network expects a batch of images with shape ``(B, 3, H, W)`` and
+    values in the ``[0, 1]`` range.  It returns a tuple containing:
+
+    * ``point`` – tensor of shape ``(B, 2)`` with normalized ``x`` and ``y``
+      coordinates in ``[0, 1]``.
+    * ``click`` – tensor of shape ``(B, 1)`` with click probability in
+      ``[0, 1]``.
+    """
+
+    def __init__(
+        self,
+        weights: models.ResNet18_Weights | None = None,
+    ) -> None:
+        """Initialize the policy.
+
+        Args:
+            weights: Optional torchvision weights used to initialize the
+                ResNet18 backbone.
+        """
+
         super().__init__()
-        base = models.resnet18(weights=None)
+        base = models.resnet18(weights=weights)
         base.fc = nn.Identity()
         self.backbone = base
         self.head_point = nn.Sequential(
@@ -16,7 +39,19 @@ class ClickPolicy(nn.Module):
             nn.Linear(512, 128), nn.ReLU(), nn.Linear(128, 1), nn.Sigmoid()
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run a forward pass.
+
+        Args:
+            x: Batch of images with shape ``(B, 3, H, W)`` and values in
+                ``[0, 1]``.
+
+        Returns:
+            A tuple ``(point, click)`` where ``point`` has shape ``(B, 2)`` and
+            ``click`` has shape ``(B, 1)``. Both outputs are in the ``[0, 1]``
+            range.
+        """
+
         f = self.backbone(x)
         point = self.head_point(f)  # (B,2) w [0,1]
         click = self.head_click(f)  # (B,1) w [0,1]

--- a/agent/model_kbd.py
+++ b/agent/model_kbd.py
@@ -1,18 +1,47 @@
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 import torchvision.models as models
 
 
 class KbdPolicy(nn.Module):
-    def __init__(self):
+    """Predicts keyboard actions from an RGB screenshot.
+
+    The model expects input tensors of shape ``(B, 3, H, W)`` with values in
+    ``[0, 1]`` and outputs four probabilities corresponding to the ``W``, ``A``,
+    ``S`` and ``D`` keys.
+    """
+
+    def __init__(
+        self,
+        weights: models.ResNet18_Weights | None = None,
+    ) -> None:
+        """Initialize the policy.
+
+        Args:
+            weights: Optional torchvision weights for the ResNet18 backbone.
+        """
+
         super().__init__()
-        base = models.resnet18(weights=None)
+        base = models.resnet18(weights=weights)
         base.fc = nn.Identity()
         self.backbone = base
         self.head = nn.Sequential(
             nn.Linear(512, 256), nn.ReLU(), nn.Linear(256, 4), nn.Sigmoid()
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run a forward pass.
+
+        Args:
+            x: Batch of images with shape ``(B, 3, H, W)`` and values in
+                ``[0, 1]``.
+
+        Returns:
+            Tensor of shape ``(B, 4)`` with probabilities for ``W``, ``A``,
+            ``S`` and ``D`` keys in the ``[0, 1]`` range.
+        """
+
         f = self.backbone(x)
         return self.head(f)  # W,A,S,D w [0,1]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,25 @@
+import torch
+import torchvision.models as models
+import pytest
+
+from agent.model import ClickPolicy
+from agent.model_kbd import KbdPolicy
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("weights", [None, models.ResNet18_Weights.IMAGENET1K_V1])
+def test_click_policy_forward(weights):
+    model = ClickPolicy(weights=weights)
+    x = torch.rand(1, 3, 224, 224)
+    point, click = model(x)
+    assert point.shape == (1, 2)
+    assert click.shape == (1, 1)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("weights", [None, models.ResNet18_Weights.IMAGENET1K_V1])
+def test_kbd_policy_forward(weights):
+    model = KbdPolicy(weights=weights)
+    x = torch.rand(1, 3, 224, 224)
+    out = model(x)
+    assert out.shape == (1, 4)


### PR DESCRIPTION
## Summary
- document ClickPolicy and KbdPolicy models and their I/O
- allow passing optional pretrained ResNet18 weights
- exercise models in tests with and without pretrained weights

## Testing
- `pytest tests/test_models.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68b15f63d5b8833085733b9f1e71e1cf