### PR TITLE
Use QtGui shortcut in teleport config dialog

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -222,7 +222,7 @@ class TeleportConfigDialog(QtWidgets.QDialog):
 
         self._populate()
 
-        self._f2_shortcut = QtWidgets.QShortcut(
+        self._f2_shortcut = QtGui.QShortcut(
             QtGui.QKeySequence(QtCore.Qt.Key_F2), self
         )
         self._f2_shortcut.setContext(QtCore.Qt.ApplicationShortcut)


### PR DESCRIPTION
## Summary
- construct TeleportConfigDialog F2 shortcut with `QtGui.QShortcut`

## Testing
- `pytest` *(fails: RecursionError: maximum recursion depth exceeded)*
- Custom PySide6 script showing F2 shortcut activation

------
https://chatgpt.com/codex/tasks/task_e_68b1651098d08330b9ba0e1cd37c9650