### PR TITLE
Add teleport panel hotkey setting to GUI

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -356,6 +356,14 @@ class MainWindow(QtWidgets.QMainWindow):
         tmpl_layout.addWidget(self.btn_templates_dir)
         settings_form.addRow("Katalog szablonów:", tmpl_widget)
         self.btn_templates_dir.clicked.connect(self.browse_templates_dir)
+
+        # hotkey for opening teleport configuration dialog
+        self.tp_cfg_hotkey = QtWidgets.QLineEdit("f9")
+        self.tp_cfg_hotkey.setMaximumWidth(60)
+        settings_form.addRow("Skrót panelu teleportu:", self.tp_cfg_hotkey)
+        self.tp_cfg_hotkey.textChanged.connect(
+            lambda _: self.start_hotkey_listener()
+        )
         left.addWidget(settings_box)
 
         # agent parameters group
@@ -768,7 +776,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 "timeout_per_ch": 2.5,
                 "hotkeys": hotkeys,
             },
-            "ui": {"scale": float(self.scale_spin.value())},
+            "ui": {
+                "scale": float(self.scale_spin.value()),
+                "tp_cfg_hotkey": self.tp_cfg_hotkey.text().strip(),
+            },
         }
         return cfg
 
@@ -825,6 +836,7 @@ class MainWindow(QtWidgets.QMainWindow):
         scale = float(ui.get("scale", 1.0))
         self.scale_spin.setValue(scale)
         self.apply_scale(scale)
+        self.tp_cfg_hotkey.setText(ui.get("tp_cfg_hotkey", "f9"))
         self.prio_list.clear()
         for name in cfg.get("priority", []):
             self.prio_list.addItem(QtWidgets.QListWidgetItem(name))
@@ -837,6 +849,7 @@ class MainWindow(QtWidgets.QMainWindow):
             key = ch_hot.get(str(i)) or ch_hot.get(i) or str(i)
             self.ch_key_edits[i].setText(key)
         self.set_status("Wczytano konfigurację.")
+        self.start_hotkey_listener()
 
     # ---------- agent actions ----------
     def start_agent(self, checked: bool) -> None:
@@ -1099,13 +1112,28 @@ class MainWindow(QtWidgets.QMainWindow):
 
     # ---------- hotkey ----------
     def start_hotkey_listener(self) -> None:
+        tp_key = self.tp_cfg_hotkey.text().strip().lower()
+
         def on_press(key):
             try:
                 if key == pynput_keyboard.Key.f12:
                     self.stop_all()
+                elif tp_key:
+                    try:
+                        target = getattr(pynput_keyboard.Key, tp_key)
+                        if key == target:
+                            self.open_teleport_config()
+                    except AttributeError:
+                        if (
+                            isinstance(key, pynput_keyboard.KeyCode)
+                            and key.char == tp_key
+                        ):
+                            self.open_teleport_config()
             except Exception:
                 pass
 
+        if self._hotkey_listener:
+            self._hotkey_listener.stop()
         self._hotkey_listener = pynput_keyboard.Listener(on_press=on_press)
         self._hotkey_listener.daemon = True
         self._hotkey_listener.start()


### PR DESCRIPTION
## Summary
- allow users to configure a hotkey for opening the teleport panel
- persist the teleport panel hotkey in config save/load
- extend global hotkey listener to trigger teleport panel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bfad73a88330b543f44dd1eafb90