### PR TITLE
Add configurable cycle sequence option

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -75,6 +75,7 @@ DEFAULT_CFG: Dict[str, Any] = {
         "slots": [1, 2, 3, 4, 5, 6, 7, 8],
         "per_spot_sec": 90,
         "clear_sec": 6,
+        "sequence": [],
     },
 }
 

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -102,9 +102,81 @@ class CycleFarm:
         dets = self.det.infer(frame)
         return bool(dets)
 
+    # ---- logika pojedynczego slotu ----
+    def _process_slot(self, ch, slot, page_label, per_spot_sec, clear_sec):
+        """Obsłuż teleportację i polowanie na pojedynczym slocie."""
+
+        now = time.time()
+        key = (ch, slot)
+        last = self.cooldown.get(key, 0)
+        if now - last < self.cooldown_min * 60:
+            logger.debug("Pomijam slot %s na kanale %s - cooldown", slot, ch)
+            return
+
+        logger.info("Teleportuję na slot %s (ch%s)", slot, ch)
+        try:
+            if hasattr(self.tp, "teleport_slot"):
+                self.tp.teleport_slot(slot, page_label)
+            else:
+                self.tp.teleport(slot, page_label)
+        except Exception:
+            logger.warning(
+                "Teleportacja na slot %s kanału %s nie powiodła się", slot, ch
+            )
+            self.cooldown[key] = now
+            return
+
+        if self.scanner and not self._any_target_seen():
+            logger.debug("Brak celu po teleportacji – skanuję otoczenie")
+            self.scanner.scan()
+
+        if not self._any_target_seen() or self._stop:
+            logger.info("Brak celu na slocie %s kanału %s", slot, ch)
+            self.cooldown[key] = time.time()
+            return
+
+        logger.debug("Rozpoczynam polowanie na slocie %s kanału %s", slot, ch)
+        t_end = time.time() + float(per_spot_sec)
+        last_seen = time.time()
+        while time.time() < t_end and not self._stop:
+            self.agent.step()
+            if self._any_target_seen():
+                last_seen = time.time()
+            elif time.time() - last_seen > float(clear_sec):
+                if self.scanner:
+                    self.scanner.scan()
+                if not self._any_target_seen():
+                    self.ch.cycle_until_target_seen(
+                        check_fn=self._any_target_seen,
+                        settle=self.ch_settle,
+                        timeout_per_ch=self.ch_check,
+                        max_rounds=1,
+                    )
+                if not self._any_target_seen():
+                    logger.debug("Pole czyste – przechodzę dalej")
+                    break
+                last_seen = time.time()
+
+        self.cooldown[key] = time.time()
+
     # ---- główna pętla cyklu ----
-    def run(self, page_label, ch_from, ch_to, slots, per_spot_sec, clear_sec):
+    def run(
+        self,
+        page_label,
+        ch_from,
+        ch_to,
+        slots,
+        per_spot_sec,
+        clear_sec,
+        sequence=None,
+    ):
         """Główna pętla cyklu farmienia.
+
+        "sequence" pozwala określić pełną kolejność odwiedzania kanałów i
+        slotów.  Każdy element listy powinien być dwuelementowym iterowalnym
+        (ch, slot) lub słownikiem z kluczami ``ch`` i ``slot``.  Gdy sekwencja
+        jest podana, parametry ``ch_from``, ``ch_to`` oraz ``slots`` są
+        ignorowane.
 
         Parameters
         ----------
@@ -118,87 +190,37 @@ class CycleFarm:
             Maksymalny czas polowania na jednym spocie.
         clear_sec: float
             Czas bez celu po którym uznajemy spot za czysty.
+        sequence: Iterable
+            Opcjonalna pełna sekwencja (kanał, slot).
         """
 
-        # Przejście przez kanały oraz sloty
-        for ch in range(ch_from, ch_to + 1):
+        if sequence:
+            steps = []
+            for item in sequence:
+                if isinstance(item, dict):
+                    steps.append((item["ch"], item["slot"]))
+                else:
+                    ch, slot = item
+                    steps.append((ch, slot))
+        else:
+            steps = [
+                (ch, slot) for ch in range(ch_from, ch_to + 1) for slot in slots
+            ]
+
+        current_ch = None
+        for ch, slot in steps:
             if self._stop:
                 break
-
-            # zmiana kanału
-            logger.info("Przechodzę na kanał %s", ch)
-            try:
-                self.ch.switch(ch, post_wait=self.ch_settle)
-            except Exception:
-                logger.warning("Nie udało się zmienić kanału na %s", ch)
-
-            for slot in slots:
-                if self._stop:
-                    break
-
-                # sprawdzenie cooldownu dla (ch, slot)
-                now = time.time()
-                key = (ch, slot)
-                last = self.cooldown.get(key, 0)
-                if now - last < self.cooldown_min * 60:
-                    logger.debug("Pomijam slot %s na kanale %s - cooldown", slot, ch)
-                    continue
-
-                # teleportacja do slotu
-                logger.info("Teleportuję na slot %s (ch%s)", slot, ch)
+            if ch != current_ch:
+                logger.info("Przechodzę na kanał %s", ch)
                 try:
-                    # większość logiki teleportu (otwarcie panelu itp.)
-                    # znajduje się w klasie Teleporter
-                    if hasattr(self.tp, "teleport_slot"):
-                        self.tp.teleport_slot(slot, page_label)
-                    else:
-                        self.tp.teleport(slot, page_label)
+                    self.ch.switch(ch, post_wait=self.ch_settle)
                 except Exception:
-                    logger.warning(
-                        "Teleportacja na slot %s kanału %s nie powiodła się", slot, ch
-                    )
-                    # jeśli teleportacja się nie udała, pomijamy slot
-                    self.cooldown[key] = now
-                    continue
+                    logger.warning("Nie udało się zmienić kanału na %s", ch)
+                current_ch = ch
+            if self._stop:
+                break
+            self._process_slot(ch, slot, page_label, per_spot_sec, clear_sec)
 
-                # ewentualne skanowanie po teleportacji
-                if self.scanner and not self._any_target_seen():
-                    logger.debug("Brak celu po teleportacji – skanuję otoczenie")
-                    self.scanner.scan()
-
-                # jeżeli nadal brak celu, od razu kolejny slot
-                if not self._any_target_seen() or self._stop:
-                    logger.info("Brak celu na slocie %s kanału %s", slot, ch)
-                    self.cooldown[key] = time.time()
-                    continue
-
-                # główna pętla polowania na spocie
-                logger.debug("Rozpoczynam polowanie na slocie %s kanału %s", slot, ch)
-                t_end = time.time() + float(per_spot_sec)
-                last_seen = time.time()
-                while time.time() < t_end and not self._stop:
-                    self.agent.step()
-                    if self._any_target_seen():
-                        last_seen = time.time()
-                    elif time.time() - last_seen > float(clear_sec):
-                        # spróbuj przeskanować otoczenie
-                        if self.scanner:
-                            self.scanner.scan()
-                        if not self._any_target_seen():
-                            self.ch.cycle_until_target_seen(
-                                check_fn=self._any_target_seen,
-                                settle=self.ch_settle,
-                                timeout_per_ch=self.ch_check,
-                                max_rounds=1,
-                            )
-                        if not self._any_target_seen():
-                            logger.debug("Pole czyste – przechodzę dalej")
-                            break
-                        last_seen = time.time()
-
-                # zapisz cooldown na odwiedzony slot
-                self.cooldown[key] = time.time()
-
-        # zakończ po przejściu całego cyklu
         self.win.close()
         return

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -49,3 +49,8 @@ cycle:
   slots: [1,2,3,4,5,6,7,8]
   per_spot_sec: 90
   clear_sec: 6
+  # opcjonalna pełna sekwencja (kanał i slot) zastępująca powyższe
+  # zakresy.  Kolejne kroki mogą być podane dowolnej długości.
+  # sequence:
+  #   - {ch: 1, slot: 1}
+  #   - {ch: 2, slot: 3}

--- a/gui/app.py
+++ b/gui/app.py
@@ -975,6 +975,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     slots=cycle_cfg.get("slots", list(range(1, 9))),
                     per_spot_sec=cycle_cfg.get("per_spot_sec", 90),
                     clear_sec=cycle_cfg.get("clear_sec", 6),
+                    sequence=cycle_cfg.get("sequence"),
                 )
                 self.set_status("Cykl 8×8 zakończony.")
             except Exception as exc:

--- a/tests/test_cycle_sequence.py
+++ b/tests/test_cycle_sequence.py
@@ -1,0 +1,117 @@
+import numpy as np
+
+
+def test_cycle_sequence(monkeypatch):
+    import types
+    import sys
+    from pathlib import Path
+
+    # Stub optional dependencies before importing agent modules.
+    sys.modules.setdefault("ultralytics", types.SimpleNamespace(YOLO=object))
+    sys.modules.setdefault("pyautogui", types.SimpleNamespace())
+    sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: None))
+    sys.modules.setdefault("pygetwindow", types.SimpleNamespace(getAllWindows=lambda: []))
+    sys.modules.setdefault("win32con", types.SimpleNamespace())
+    sys.modules.setdefault("win32gui", types.SimpleNamespace())
+    sys.modules.setdefault(
+        "cv2", types.SimpleNamespace(TM_CCOEFF_NORMED=0, setNumThreads=lambda n: None)
+    )
+    sys.modules.setdefault("easyocr", types.SimpleNamespace())
+    pil = types.ModuleType("PIL")
+    pil_image = types.ModuleType("PIL.Image")
+    pil.Image = pil_image
+    sys.modules.setdefault("PIL", pil)
+    sys.modules.setdefault("PIL.Image", pil_image)
+
+    # Ensure repository root is on sys.path when running standalone
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+
+    from agent.cycle import CycleFarm
+
+    calls = []
+
+    class DummyWindow:
+        def __init__(self, title):
+            pass
+
+        def locate(self, timeout=0):
+            return True
+
+        def grab(self):
+            return np.zeros((1, 1, 3), dtype=np.uint8)
+
+        def close(self):
+            pass
+
+    class DummyTeleporter:
+        def __init__(self, *a, **k):
+            pass
+
+        def teleport_slot(self, slot, page_label):
+            calls.append(("tp", slot, page_label))
+
+    class DummyChannelSwitcher:
+        def __init__(self, *a, **k):
+            pass
+
+        def switch(self, ch, post_wait=0):
+            calls.append(("ch", ch))
+
+    class DummyKeyHold:
+        def __init__(self, *a, **k):
+            pass
+
+        def stop(self):
+            pass
+
+    class DummyHuntDestroy:
+        def __init__(self, cfg, win):
+            pass
+
+        def step(self):
+            pass
+
+    class DummyDetector:
+        def __init__(self, *a, **k):
+            pass
+
+        def infer(self, frame):
+            return []
+
+    monkeypatch.setattr("agent.cycle.WindowCapture", DummyWindow)
+    monkeypatch.setattr("agent.cycle.Teleporter", DummyTeleporter)
+    monkeypatch.setattr("agent.cycle.ChannelSwitcher", DummyChannelSwitcher)
+    monkeypatch.setattr("agent.cycle.KeyHold", DummyKeyHold)
+    monkeypatch.setattr("agent.cycle.HuntDestroy", DummyHuntDestroy)
+    monkeypatch.setattr("agent.cycle.ObjectDetector", DummyDetector)
+
+    cfg = {
+        "window": {"title_substr": "x"},
+        "paths": {"templates_dir": "", "model": ""},
+        "detector": {"classes": []},
+        "scan": {"enabled": False},
+        "cooldowns": {"slot_min": 0},
+    }
+    cf = CycleFarm(cfg)
+    cf._any_target_seen = lambda: False
+    seq = [
+        {"ch": 1, "slot": 1},
+        {"ch": 2, "slot": 3},
+        {"ch": 2, "slot": 4},
+        {"ch": 1, "slot": 2},
+    ]
+    cf.run(
+        page_label="P",
+        ch_from=1,
+        ch_to=2,
+        slots=[1, 2],
+        per_spot_sec=0,
+        clear_sec=0,
+        sequence=seq,
+    )
+
+    switches = [c[1] for c in calls if c[0] == "ch"]
+    teleports = [c[1] for c in calls if c[0] == "tp"]
+    assert switches == [1, 2, 1]
+    assert teleports == [1, 3, 4, 2]


### PR DESCRIPTION
## Summary
- allow `CycleFarm.run` to follow a custom `(channel, slot)` sequence
- expose `cycle.sequence` in default and sample configs
- pass sequence from GUI and add unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c2a3a4748330bcf7700bb3d865f9