### PR TITLE
Use KeyHold for teleport hotkey

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -14,7 +14,11 @@ from recorder.window_capture import WindowCapture
 
 from . import get_config
 from .template_matcher import TemplateMatcher
-from .wasd import KeyHold
+
+try:  # pragma: no cover - prefer pydirectinput if available
+    from pydirectinput import KeyHold  # type: ignore
+except Exception:  # pragma: no cover - fallback to local implementation
+    from .wasd import KeyHold
 
 CFG = get_config()
 pyautogui.PAUSE = CFG.get("controls", {}).get("mouse_pause", 0.02)
@@ -133,7 +137,10 @@ class Teleporter:
         for attempt in range(max_attempts):
             logger.debug("Attempt %d to open teleport panel", attempt + 1)
             if not self.dry:
-                pyautogui.hotkey("ctrl", "x")
+                self.keys.press("ctrl")
+                self.keys.press("x")
+                self.keys.release("x")
+                self.keys.release("ctrl")
             else:
                 return True
             time.sleep(self.open_panel_delay)


### PR DESCRIPTION
## Summary
- prefer KeyHold from pydirectinput when available
- open teleport panel using KeyHold key presses

## Testing
- `python -m flake8 agent/teleport.py`
- `python -m black --check agent/teleport.py`
- `isort --check-only agent/teleport.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57d2a9fd88330a941a0e0f8fcc185