### PR TITLE
Refactor template matching result handling

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import time
-from dataclasses import dataclass
 from typing import Callable, Optional, Tuple
 
 import numpy as np
@@ -10,27 +9,8 @@ import pyautogui
 
 from recorder.window_capture import WindowCapture
 
-from .template_matcher import TemplateMatcher
+from .template_matcher import TemplateMatch, TemplateMatcher
 from .wasd import KeyHold, pydirectinput
-
-
-@dataclass
-class TemplateMatch:
-    """Data returned when a template is successfully matched.
-
-    Attributes
-    ----------
-    rect:
-        Bounding box of the match in ``(x, y, w, h)`` format.
-    center:
-        Coordinates of the match centre ``(x, y)``.
-    score:
-        Matching score between ``0`` and ``1``.
-    """
-
-    rect: Tuple[int, int, int, int]
-    center: Tuple[int, int]
-    score: float
 
 
 class ChannelSwitcher:
@@ -134,15 +114,7 @@ class ChannelSwitcher:
             roi = self._minimap_roi()
         name = f"ch{ch}"
         res = self.tm.find(frame, name, thresh=thresh, roi=roi, multi_scale=True)
-        if not res:
-            return None
-        if isinstance(res, TemplateMatch):
-            return res
-        return TemplateMatch(
-            rect=tuple(res["rect"]),
-            center=tuple(res["center"]),
-            score=float(res["score"]),
-        )
+        return res
 
     def color_at(
         self, x: int, y: int, frame: Optional[np.ndarray] = None

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -191,7 +191,7 @@ class Teleporter:
         if not m:
             return False
         L, T, _, _ = self.win.region
-        cx, cy = m["center"]
+        cx, cy = m.center
         self._safe_click(L + cx, T + cy)
         time.sleep(self.after_page_delay)
         return True
@@ -257,7 +257,7 @@ class Teleporter:
             logger.info("Load button not found for slot %s", slot)
             self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
             return TeleportResult.TEMPLATE_NOT_FOUND
-        cx, cy = m["center"]
+        cx, cy = m.center
         logger.debug("Clicking load button at (%d, %d)", L + cx, T + cy)
         self._safe_click(L + cx, T + cy)
         time.sleep(self.after_load_delay)

--- a/agent/template_matcher.py
+++ b/agent/template_matcher.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from math import hypot
 from pathlib import Path
+from typing import Tuple
 
 import cv2
 import numpy as np
+
+
+@dataclass
+class TemplateMatch:
+    """Result of a successful template match."""
+
+    rect: Tuple[int, int, int, int]
+    center: Tuple[int, int]
+    score: float
 
 
 class TemplateMatcher:
@@ -54,7 +65,7 @@ class TemplateMatcher:
     ):
         gray, offx, offy = self._prep(frame_bgr, roi)
         tpl0 = self.load(name)
-        best = None
+        best: TemplateMatch | None = None
         for s in [1.0] if not multi_scale else scales:
             tpl = cv2.resize(
                 tpl0,
@@ -68,12 +79,12 @@ class TemplateMatcher:
             if max_val >= thresh:
                 x, y = max_loc
                 bw, bh = tpl.shape[1], tpl.shape[0]
-                cand = {
-                    "rect": (offx + x, offy + y, bw, bh),
-                    "center": (offx + x + bw // 2, offy + y + bh // 2),
-                    "score": float(max_val),
-                }
-                if best is None or cand["score"] > best["score"]:
+                cand = TemplateMatch(
+                    rect=(offx + x, offy + y, bw, bh),
+                    center=(offx + x + bw // 2, offy + y + bh // 2),
+                    score=float(max_val),
+                )
+                if best is None or cand.score > best.score:
                     best = cand
         return best
 
@@ -87,10 +98,10 @@ class TemplateMatcher:
         scales=(1.0, 0.9, 1.1, 0.8),
         dedup_px=12,
     ):
-        """Zwraca listę dopasowań (słowniki) posortowanych po Y (od góry)."""
+        """Zwraca listę dopasowań (:class:`TemplateMatch`) posortowanych po Y (od góry)."""
         gray, offx, offy = self._prep(frame_bgr, roi)
         tpl0 = self.load(name)
-        found = []
+        found: list[TemplateMatch] = []
         for s in [1.0] if not multi_scale else scales:
             tpl = cv2.resize(
                 tpl0,
@@ -107,24 +118,20 @@ class TemplateMatcher:
                 score = float(res[y, x])
                 dup = False
                 for f in found:
-                    if hypot(f["center"][0] - cx, f["center"][1] - cy) < dedup_px:
-                        if score > f["score"]:
-                            f.update(
-                                {
-                                    "rect": (offx + x, offy + y, bw, bh),
-                                    "center": (cx, cy),
-                                    "score": score,
-                                }
-                            )
+                    if hypot(f.center[0] - cx, f.center[1] - cy) < dedup_px:
+                        if score > f.score:
+                            f.rect = (offx + x, offy + y, bw, bh)
+                            f.center = (cx, cy)
+                            f.score = score
                         dup = True
                         break
                 if not dup:
                     found.append(
-                        {
-                            "rect": (offx + x, offy + y, bw, bh),
-                            "center": (cx, cy),
-                            "score": score,
-                        }
+                        TemplateMatch(
+                            rect=(offx + x, offy + y, bw, bh),
+                            center=(cx, cy),
+                            score=score,
+                        )
                     )
-        found.sort(key=lambda d: d["center"][1])
+        found.sort(key=lambda d: d.center[1])
         return found

--- a/tests/test_channel_switcher.py
+++ b/tests/test_channel_switcher.py
@@ -2,6 +2,8 @@ import importlib
 import os
 import sys
 import types
+from dataclasses import dataclass
+from typing import Tuple
 
 import pytest
 
@@ -52,7 +54,15 @@ class _TM:
         return None
 
 
+@dataclass
+class _Match:
+    rect: Tuple[int, int, int, int]
+    center: Tuple[int, int]
+    score: float
+
+
 tm_stub.TemplateMatcher = _TM
+tm_stub.TemplateMatch = _Match
 sys.modules.setdefault("agent.template_matcher", tm_stub)
 
 import agent.channel as channel


### PR DESCRIPTION
## Summary
- Introduce `TemplateMatch` dataclass and return it from `TemplateMatcher.find` and `find_all`
- Simplify `ChannelSwitcher` to use `TemplateMatch` directly from `template_matcher`
- Update `Teleporter` to access match results via dataclass attributes

## Testing
- `pytest tests/test_channel_switcher.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b580c71c2c8330a400b48fae129eea