### PR TITLE
Move train_yolo logging config into main

### DIFF
--- a/training/train_yolo.py
+++ b/training/train_yolo.py
@@ -5,10 +5,9 @@ import logging
 
 from ultralytics import YOLO
 
-logging.basicConfig(level=logging.INFO)
-
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     ap = argparse.ArgumentParser()
     ap.add_argument("--data", required=True, help="Ścieżka do data.yaml")
     ap.add_argument("--model", default="yolov8n.pt", help="Waga startowa (lokalna)")


### PR DESCRIPTION
## Summary
- Avoid configuring logging on import in `training/train_yolo.py` by moving `logging.basicConfig` inside `main`

## Testing
- `python training/train_yolo.py --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5831e132c83308d087e3ed5b485f4