### PR TITLE
Cache teleport configuration with reload support

### DIFF
--- a/agent/teleport_config.py
+++ b/agent/teleport_config.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import types
 import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Callable
+from typing import Any, Callable, Dict, List, Tuple
 
 try:  # pyautogui is optional during tests
     import pyautogui
@@ -40,18 +41,45 @@ def save_teleport_config(data: Dict[str, Any], path: str | Path = "config/telepo
         yaml.safe_dump(data, f, allow_unicode=True)
 
 
-_cfg = load_teleport_config()
+@dataclass
+class TeleportRuntimeConfig:
+    """Runtime helper values derived from the YAML configuration."""
 
-# Delays configurable via ``config/teleport.yaml`` with sane defaults
-DELAY_AFTER_PANEL: float = float(_cfg.get("delay_after_panel", 0.5))
-DELAY_AFTER_TELEPORT: float = float(_cfg.get("delay_after_teleport", 1.0))
-DELAY_AFTER_CHANNEL: float = float(_cfg.get("delay_after_channel", 5.0))
+    config: Dict[str, Any]
+    delay_after_panel: float
+    delay_after_teleport: float
+    delay_after_channel: float
+    positions_by_channel: Dict[int, List[Tuple[int, int]]]
+    channel_buttons: Dict[int, Tuple[int, int]]
 
-# Public mappings with fallback to empty structures
-positions_by_channel: Dict[int, List[Tuple[int, int]]] = _cfg.get(
-    "positions_by_channel", {}
-)
-channel_buttons: Dict[int, Tuple[int, int]] = _cfg.get("channel_buttons", {})
+
+_cfg_cache: TeleportRuntimeConfig | None = None
+_cfg_mtime: float | None = None
+
+
+def get_config(path: str | Path = "config/teleport.yaml") -> TeleportRuntimeConfig:
+    """Return cached configuration data, reloading when the file changes."""
+
+    global _cfg_cache, _cfg_mtime
+    p = Path(path)
+    try:
+        mtime = p.stat().st_mtime
+    except FileNotFoundError:
+        mtime = None
+
+    if _cfg_cache is None or mtime != _cfg_mtime:
+        raw = load_teleport_config(path)
+        _cfg_cache = TeleportRuntimeConfig(
+            config=raw,
+            delay_after_panel=float(raw.get("delay_after_panel", 0.5)),
+            delay_after_teleport=float(raw.get("delay_after_teleport", 1.0)),
+            delay_after_channel=float(raw.get("delay_after_channel", 5.0)),
+            positions_by_channel=raw.get("positions_by_channel", {}),
+            channel_buttons=raw.get("channel_buttons", {}),
+        )
+        _cfg_mtime = mtime
+    return _cfg_cache
+
 
 def open_panel() -> None:  # pragma: no cover - provided by the game
     """Open the in‑game teleport panel.
@@ -64,41 +92,37 @@ def open_panel() -> None:  # pragma: no cover - provided by the game
 def run_positions(
     channel: int,
     *,
-    delay: float = DELAY_AFTER_TELEPORT,
+    delay: float | None = None,
     close_panel: Callable[[], None] | None = None,
 ) -> None:
-    """Run all configured positions for ``channel``.
+    """Run all configured positions for ``channel``."""
 
-    The teleport panel is opened once via :func:`open_panel`.  For each of the
-    eight stored positions the function performs a click, sends the interaction
-    key ``E`` and waits ``delay`` seconds for in‑game actions to complete.  When
-    ``close_panel`` is provided it is invoked after each position which allows
-    the caller to close the panel between teleports if necessary.
-    """
-
-    positions = positions_by_channel.get(channel)
+    cfg = get_config()
+    positions = cfg.positions_by_channel.get(channel)
     if not positions:
         return
 
     open_panel()
-    time.sleep(DELAY_AFTER_PANEL)
+    time.sleep(cfg.delay_after_panel)
+    sleep_delay = delay if delay is not None else cfg.delay_after_teleport
     for x, y in positions:
         pyautogui.click(x, y)
         pyautogui.press("e")
-        time.sleep(delay)
+        time.sleep(sleep_delay)
         if close_panel:
             close_panel()
 
 
-def change_channel(target_ch: int, *, delay: float = DELAY_AFTER_CHANNEL) -> None:
+def change_channel(target_ch: int, *, delay: float | None = None) -> None:
     """Click the button for ``target_ch`` and wait for a channel switch."""
 
-    coords = channel_buttons.get(target_ch)
+    cfg = get_config()
+    coords = cfg.channel_buttons.get(target_ch)
     if not coords:
         return
     x, y = coords
     pyautogui.click(x, y)
-    time.sleep(delay)
+    time.sleep(delay if delay is not None else cfg.delay_after_channel)
 
 
 def main() -> None:  # pragma: no cover - helper script
@@ -109,13 +133,9 @@ def main() -> None:  # pragma: no cover - helper script
 
 
 __all__ = [
-    "positions_by_channel",
-    "channel_buttons",
-    "DELAY_AFTER_PANEL",
-    "DELAY_AFTER_TELEPORT",
-    "DELAY_AFTER_CHANNEL",
     "load_teleport_config",
     "save_teleport_config",
+    "get_config",
     "open_panel",
     "run_positions",
     "change_channel",

--- a/gui/app.py
+++ b/gui/app.py
@@ -307,8 +307,9 @@ class TeleportConfigDialog(QtWidgets.QDialog):
         data["positions_by_channel"] = pos_out
         data["channel_buttons"] = btn_out
         tc.save_teleport_config(data)
-        tc.positions_by_channel = pos_out
-        tc.channel_buttons = btn_out
+        tc._cfg_cache = None
+        tc._cfg_mtime = None
+        tc.get_config()
         super().accept()
 
 

--- a/tests/test_teleport_config.py
+++ b/tests/test_teleport_config.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import types
 
 pyautogui_stub = types.ModuleType("pyautogui")
@@ -19,7 +20,9 @@ import agent.teleport_config as tc
 
 def test_change_channel(monkeypatch):
     calls = []
-    monkeypatch.setattr(tc, "channel_buttons", {2: (10, 20)})
+
+    cfg = tc.TeleportRuntimeConfig({}, 0.0, 0.0, 5.0, {}, {2: (10, 20)})
+    monkeypatch.setattr(tc, "get_config", lambda path="config/teleport.yaml": cfg)
     monkeypatch.setattr(tc.pyautogui, "click", lambda x, y: calls.append((x, y)))
     monkeypatch.setattr(tc.time, "sleep", lambda s: calls.append(s))
     tc.change_channel(2)
@@ -49,3 +52,25 @@ def test_save_teleport_config(tmp_path, monkeypatch):
     tc.save_teleport_config(data, path)
     assert path.read_text() == "written"
     assert captured["data"] == data
+
+
+def test_get_config_reload(tmp_path, monkeypatch):
+    path = tmp_path / "tp.yaml"
+    path.write_text("first")
+
+    data = {"delay_after_panel": 1.0}
+
+    def fake_load(p):
+        return data
+
+    monkeypatch.setattr(tc, "load_teleport_config", fake_load)
+    tc._cfg_cache = None
+    tc._cfg_mtime = None
+    cfg1 = tc.get_config(path)
+    assert cfg1.delay_after_panel == 1.0
+
+    time.sleep(0.01)
+    path.write_text("second")
+    data["delay_after_panel"] = 2.0
+    cfg2 = tc.get_config(path)
+    assert cfg2.delay_after_panel == 2.0


### PR DESCRIPTION
## Summary
- centralize teleport settings with `get_config` that caches file contents and reloads when the YAML changes
- update runtime helpers to read configuration through `get_config`
- refresh config cache from GUI after saving
- add regression test for config reload behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58c31fbf483309cf9d535af68e3e0