### PR TITLE
Ensure window focus for game input and refresh capture region

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -155,7 +155,7 @@ class ChannelSwitcher:
 
         if not (1 <= ch <= 8):
             raise ValueError("Kanał poza zakresem 1..8")
-
+        self.win.focus()
         roi = self._minimap_roi()
         for _ in range(tries):
             frame = self._frame()

--- a/agent/interaction.py
+++ b/agent/interaction.py
@@ -49,10 +49,9 @@ def click_bbox_center(
     cy = int(top + (y1 + y2) / 2)
 
     if win is not None:
+        win.focus()
         if not win.is_foreground():
-            win.focus()
-            if not win.is_foreground():
-                return False
+            return False
 
     if not rate_limit or _rate_limit_ok():
         pyautogui.moveTo(cx, cy, duration=0)

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -101,10 +101,9 @@ class Teleporter:
     def _safe_click(self, x: int, y: int) -> None:
         if self.dry:
             return
+        self.win.focus()
         if not self.win.is_foreground():
-            self.win.focus()
-            if not self.win.is_foreground():
-                return
+            return
         pyautogui.moveTo(x, y, duration=self.click_duration)
         pyautogui.click()
 
@@ -119,10 +118,9 @@ class Teleporter:
         :class:`RuntimeError`.
         """
 
+        self.win.focus()
         if not self.win.is_foreground():
-            self.win.focus()
-            if not self.win.is_foreground():
-                return False
+            return False
 
         L, T, w, h = self.win.region
         roi = (

--- a/gui/app.py
+++ b/gui/app.py
@@ -575,6 +575,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.video.setMinimumSize(self.base_video_size)
         self.video.setStyleSheet("background:#222; border:1px solid #444")
         self.video.setAlignment(QtCore.Qt.AlignCenter)
+        self.video.setFocusPolicy(QtCore.Qt.NoFocus)
         right.addWidget(self.video)
 
         # thread references

--- a/recorder/window_capture.py
+++ b/recorder/window_capture.py
@@ -104,10 +104,11 @@ class WindowCapture:
         except Exception:
             return False
 
-    def grab(self):
+    def grab(self, update_region: bool = False):
         """Zwraca mss.base.ScreenShot (BGRA)."""
-        if self.region is None:
+        if update_region or self.region is None:
             self.update_region()
+
         def _grab():
             left, top, width, height = self.region
             return self.sct.grab(
@@ -119,5 +120,7 @@ class WindowCapture:
             self.update_region()
             img = _grab()
             if getattr(img, "width", 0) == 0 or getattr(img, "height", 0) == 0:
-                raise RuntimeError("WindowCapture.grab captured empty image (zero width/height)")
+                raise RuntimeError(
+                    "WindowCapture.grab captured empty image (zero width/height)"
+                )
         return img


### PR DESCRIPTION
## Summary
- Always focus game window before sending clicks or hotkeys
- Prevent preview label from stealing focus in GUI
- Allow updating window capture region on demand

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b68fdb197c8330b1d8604c0cbf70f9