### PR TITLE
feat: add strategy plugin system

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -23,6 +23,7 @@ except Exception:  # pragma: no cover - provide dummy fallback
 # Default configuration used when keys are missing from the YAML file.
 # ---------------------------------------------------------------------------
 DEFAULT_CFG: Dict[str, Any] = {
+    "strategy": "hunt_destroy",
     "window": {"title_substr": "Metin2"},
     "paths": {
         "templates_dir": "assets/templates",

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -8,7 +8,7 @@ import numpy as np
 from agent import get_config
 from agent.channel import ChannelSwitcher
 from agent.detector import ObjectDetector
-from agent.hunt_destroy import HuntDestroy
+from agent.strategy import load_strategy
 from agent.scanner import AreaScanner
 from agent.teleport import Teleporter
 from agent.wasd import KeyHold
@@ -45,7 +45,7 @@ class CycleFarm:
             keys=self.keys,
             hotkeys=cfg.get("channel", {}).get("hotkeys"),
         )
-        self.agent = HuntDestroy(cfg, self.win)
+        self.agent = load_strategy(cfg, self.win)
         self.det = ObjectDetector(cfg["paths"]["model"], cfg["detector"]["classes"])
         self._stop = False
 

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -12,6 +12,7 @@ from .interaction import click_bbox_center
 from .movement import MovementController
 from .scanner import AreaScanner
 from .search import SearchManager
+from .strategy import AgentStrategy, register
 from .targets import pick_target
 from .teleport import Teleporter
 from .wasd import KeyHold
@@ -19,8 +20,29 @@ from .wasd import KeyHold
 logger = logging.getLogger(__name__)
 
 
-class HuntDestroy:
+@register("hunt_destroy")
+class HuntDestroy(AgentStrategy):
     def __init__(self, cfg=None, window_capture=None):
+        self.cfg = None
+        self.win = None
+        self.det = None
+        self.avoid = None
+        self.keys = None
+        self.teleporter = None
+        self.channel_switcher = None
+        self.desired_w = 0.0
+        self.deadzone = 0.0
+        self.priority = []
+        self.period = 0.0
+        self.scanner = None
+        self.search = None
+        self.movement = None
+        self._last_tgt = None
+        self._prev_names: set[str] = set()
+        if cfg is not None or window_capture is not None:
+            self.setup(cfg, window_capture)
+
+    def setup(self, cfg=None, window_capture=None):
         cfg = cfg or get_config()
         self.cfg = cfg
         self.win = window_capture
@@ -44,7 +66,7 @@ class HuntDestroy:
         self.priority = cfg.get("priority", ["boss", "metin", "potwory"])
         scan_cfg = cfg.get("scan", {})
         self.period = scan_cfg.get("period", 1 / 15)
-        self.scanner: AreaScanner | None = None
+        self.scanner = None
         if scan_cfg.get("enabled", True):
             rot_key = (
                 cfg.get("controls", {}).get("keys", {}).get("rotate")
@@ -74,7 +96,7 @@ class HuntDestroy:
             self.keys, self.desired_w, self.deadzone, enabled=move_enabled
         )
         self._last_tgt = None
-        self._prev_names: set[str] = set()
+        self._prev_names = set()
 
     def step(self):
         fr = self.win.grab()

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -7,7 +7,7 @@ import numpy as np
 from recorder.window_capture import WindowCapture
 
 from . import AgentConfig, TeleportSlot
-from .hunt_destroy import HuntDestroy
+from .strategy import load_strategy
 
 
 class WasdVisionAgent:
@@ -53,7 +53,7 @@ class WasdVisionAgent:
         try:
             if not self.win.locate(timeout=5):
                 raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
-            self.hd = HuntDestroy(self.cfg, self.win)
+            self.hd = load_strategy(self.cfg, self.win)
             while True:
                 self.hd.step()
                 time.sleep(self.period)

--- a/agent/strategy.py
+++ b/agent/strategy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib
+from typing import Protocol, Type, Dict, Callable
+
+
+class AgentStrategy(Protocol):
+    """Interface for agent strategies."""
+
+    def setup(self, cfg=None, window_capture=None) -> None:
+        """Initialise the strategy with configuration and window capture."""
+        ...
+
+    def step(self) -> None:
+        """Execute a single step of the strategy."""
+        ...
+
+
+_STRATEGIES: Dict[str, Type[AgentStrategy]] = {}
+
+
+def register(name: str) -> Callable[[Type[AgentStrategy]], Type[AgentStrategy]]:
+    """Decorator registering a strategy implementation under ``name``."""
+
+    def decorator(cls: Type[AgentStrategy]) -> Type[AgentStrategy]:
+        _STRATEGIES[name] = cls
+        return cls
+
+    return decorator
+
+
+def load_strategy(cfg=None, window_capture=None) -> AgentStrategy:
+    """Load and instantiate strategy specified in ``cfg``.
+
+    The configuration may contain the key ``"strategy"`` naming the desired
+    strategy module.  Strategies register themselves via :func:`register`.
+    """
+
+    name = (cfg or {}).get("strategy", "hunt_destroy")
+    if name not in _STRATEGIES:
+        importlib.import_module(f"agent.{name}")
+    cls = _STRATEGIES.get(name)
+    if cls is None:
+        raise ValueError(f"Unknown strategy '{name}'")
+    strategy = cls()
+    strategy.setup(cfg, window_capture)
+    return strategy
+
+
+__all__ = ["AgentStrategy", "register", "load_strategy"]

--- a/gui/app.py
+++ b/gui/app.py
@@ -47,7 +47,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 from agent.channel import ChannelSwitcher
 from agent.cycle import CycleFarm
 from agent.detector import ObjectDetector
-from agent.hunt_destroy import HuntDestroy
+from agent.strategy import load_strategy
 from agent.teleport import Teleporter, TeleportResult
 from agent.wasd import KeyHold
 from recorder.window_capture import WindowCapture
@@ -923,7 +923,7 @@ class MainWindow(QtWidgets.QMainWindow):
         def run():
             cap = WindowCapture(cfg["window"]["title_substr"])
             try:
-                agent = HuntDestroy(cfg, cap)
+                agent = load_strategy(cfg, cap)
                 if not agent.win.locate(timeout=5):
                     self.set_status("Nie znaleziono okna.")
                     return
@@ -989,7 +989,7 @@ class MainWindow(QtWidgets.QMainWindow):
                         TeleportResult.WINDOW_NOT_FOREGROUND: "Okno gry nie jest aktywne.",
                     }
                     self.set_status(msg_map.get(res, "Teleportacja nie powiodła się."))
-                hd = HuntDestroy(cfg, win)
+                hd = load_strategy(cfg, win)
                 t_end = time.time() + minutes * 60
                 period = cfg.get("scan", {}).get("period", 1 / 15)
                 while time.time() < t_end and not self._panic:

--- a/tests/test_cycle_sequence.py
+++ b/tests/test_cycle_sequence.py
@@ -83,8 +83,8 @@ def test_cycle_sequence(monkeypatch):
     monkeypatch.setattr("agent.cycle.Teleporter", DummyTeleporter)
     monkeypatch.setattr("agent.cycle.ChannelSwitcher", DummyChannelSwitcher)
     monkeypatch.setattr("agent.cycle.KeyHold", DummyKeyHold)
-    monkeypatch.setattr("agent.cycle.HuntDestroy", DummyHuntDestroy)
     monkeypatch.setattr("agent.cycle.ObjectDetector", DummyDetector)
+    monkeypatch.setattr("agent.cycle.load_strategy", lambda cfg, win: DummyHuntDestroy(cfg, win))
 
     cfg = {
         "window": {"title_substr": "x"},


### PR DESCRIPTION
## Summary
- define AgentStrategy protocol and plugin registry
- refactor HuntDestroy to implement and register as a strategy
- load strategies dynamically based on cfg["strategy"]

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6954691b88330954ef90cb854a38f