### PR TITLE
Use Pydantic models for agent config

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,119 +1,33 @@
-"""Configuration loader for the Metin2 agent.
-
-This module exposes :func:`get_config` which loads ``config/agent.yaml``
-and merges it with a set of sane defaults.  Other modules simply import
-:func:`get_config` to obtain a dictionary with configuration values.
-Missing entries fall back to defaults so that incomplete configuration files
-never cause runtime errors.
-"""
+"""Configuration loader for the Metin2 agent using Pydantic models."""
 
 from __future__ import annotations
 
-import copy
 from pathlib import Path
-from typing import Any, Dict
 import types
+
+from config.models import AgentConfig, TeleportSlot
 
 try:  # yaml is optional for tests
     import yaml
 except Exception:  # pragma: no cover - provide dummy fallback
     yaml = types.SimpleNamespace(safe_load=lambda f: {})
 
-# ---------------------------------------------------------------------------
-# Default configuration used when keys are missing from the YAML file.
-# ---------------------------------------------------------------------------
-DEFAULT_CFG: Dict[str, Any] = {
-    "strategy": "hunt_destroy",
-    "window": {"title_substr": "Metin2"},
-    "paths": {
-        "templates_dir": "assets/templates",
-        "model": "runs/detect/train/weights/best.pt",
-    },
-    "controls": {
-        "keys": {
-            "forward": "w",
-            "left": "a",
-            "back": "s",
-            "right": "d",
-            "rotate": "e",
-        },
-        "movement": True,
-        "key_repeat_ms": 60,
-        "mouse_pause": 0.02,
-    },
-    "detector": {
-        "classes": ["metin", "boss", "potwory"],
-        "conf_thr": 0.5,
-        "iou_thr": 0.45,
-    },
-    "policy": {"deadzone_x": 0.05, "desired_box_w": 0.12},
-    "stuck": {"flow_window": 0.8, "min_flow_mag": 0.7, "rotate_ms_on_stuck": 250},
-    "scan": {
-        "enabled": True,
-        "period": 0.066,
-        "key": "e",
-        "sweeps": 8,
-        "sweep_ms": 250,
-        "idle_sec": 1.5,
-        "pause": 0.12,
-    },
-    "cooldowns": {"slot_min": 10},
-    "priority": ["boss", "metin", "potwory"],
-    "channel": {
-        "settle_sec": 5.0,
-        "timeout_per_ch": 5.0,
-        "hotkeys": {i: str(i) for i in range(1, 9)},
-    },
-    "teleport": {
-        "slots": [],
-        "no_target_sec": 10,
-        "channel_every": 8,
-    },
-    "channels": [1, 2, 3, 4, 5, 6, 7, 8],
-    "cycle": {
-        "ch_from": 1,
-        "ch_to": 8,
-        "slots": [1, 2, 3, 4, 5, 6, 7, 8],
-        "per_spot_sec": 90,
-        "clear_sec": 6,
-        "sequence": [],
-    },
-}
+_cfg: AgentConfig | None = None
 
 
-def _deep_update(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively merge ``updates`` into ``base``."""
-
-    for key, val in updates.items():
-        if isinstance(val, dict):
-            base[key] = _deep_update(base.get(key, {}), val)
-        else:
-            base[key] = val
-    return base
-
-
-_cfg: Dict[str, Any] | None = None
-
-
-def load_config(path: str | Path = "config/agent.yaml") -> Dict[str, Any]:
-    """Load configuration file and merge with defaults."""
+def load_config(path: str | Path = "config/agent.yaml") -> AgentConfig:
+    """Load configuration file into :class:`AgentConfig`."""
 
     try:
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
     except FileNotFoundError:
         data = {}
-    cfg = copy.deepcopy(DEFAULT_CFG)
-    _deep_update(cfg, data)
-    return cfg
+    return AgentConfig(**data)
 
 
-def get_config(path: str | Path = "config/agent.yaml") -> Dict[str, Any]:
-    """Return cached configuration dictionary.
-
-    The configuration is loaded on first use and then cached for subsequent
-    calls.  ``path`` is honoured only on the first invocation.
-    """
+def get_config(path: str | Path = "config/agent.yaml") -> AgentConfig:
+    """Return cached :class:`AgentConfig` instance."""
 
     global _cfg
     if _cfg is None:
@@ -121,4 +35,4 @@ def get_config(path: str | Path = "config/agent.yaml") -> Dict[str, Any]:
     return _cfg
 
 
-__all__ = ["get_config", "load_config"]
+__all__ = ["get_config", "load_config", "AgentConfig", "TeleportSlot"]

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -5,7 +5,7 @@ import time
 
 import numpy as np
 
-from agent import get_config
+from agent import AgentConfig, get_config
 from agent.channel import ChannelSwitcher
 from agent.detector import ObjectDetector
 from agent.strategy import load_strategy
@@ -25,15 +25,18 @@ class CycleFarm:
     Ma cooldown slotów (minuty) by nie wracać od razu.
     """
 
-    def __init__(self, cfg: dict | None = None):
-        cfg = cfg or get_config()
+    def __init__(self, cfg: AgentConfig | dict | None = None):
+        if cfg is None:
+            cfg = get_config()
+        elif isinstance(cfg, dict):
+            cfg = AgentConfig(**cfg)
         self.cfg = cfg
-        self.win = WindowCapture(cfg["window"]["title_substr"])
+        self.win = WindowCapture(cfg.window.title_substr)
         if not self.win.locate(timeout=5):
             raise RuntimeError("Nie znaleziono okna – sprawdź title_substr")
 
-        self.dry = cfg.get("dry_run", False)
-        tdir = cfg["paths"]["templates_dir"]
+        self.dry = cfg.dry_run
+        tdir = cfg.paths.templates_dir
         self.tp = Teleporter(self.win, tdir, use_ocr=True, dry=self.dry, cfg=cfg)
         self.keys = KeyHold(
             dry=self.dry, active_fn=getattr(self.win, "is_foreground", None)
@@ -43,28 +46,28 @@ class CycleFarm:
             tdir,
             dry=self.dry,
             keys=self.keys,
-            hotkeys=cfg.get("channel", {}).get("hotkeys"),
+            hotkeys=cfg.channel.hotkeys,
         )
         self.agent = load_strategy(cfg, self.win)
-        self.det = ObjectDetector(cfg["paths"]["model"], cfg["detector"]["classes"])
+        self.det = ObjectDetector(cfg.paths.model, cfg.detector.classes)
         self._stop = False
 
-        ch_cfg = cfg.get("channel", {})
-        self.ch_settle = float(ch_cfg.get("settle_sec", 5.0))
-        self.ch_check = float(ch_cfg.get("timeout_per_ch", 5.0))
+        ch_cfg = cfg.channel
+        self.ch_settle = float(ch_cfg.settle_sec)
+        self.ch_check = float(ch_cfg.timeout_per_ch)
 
         # progi i priorytety
-        self.conf_thr = float(cfg.get("detector", {}).get("conf_thr", 0.5))
-        self.priority = list(cfg.get("priority", []))
+        self.conf_thr = float(cfg.detector.conf_thr)
+        self.priority = list(cfg.priority)
 
         # parametry skanowania
-        scan = cfg.get("scan", {})
-        self.spin_key = scan.get("key", "e")
-        self.sweep_ms = int(scan.get("sweep_ms", 250))
-        self.sweeps = int(scan.get("sweeps", 8))
-        self.idle_before_scan = float(scan.get("idle_sec", 1.5))
-        self.pause_between_sweeps = float(scan.get("pause", 0.12))
-        self.scan_enabled = scan.get("enabled", True)
+        scan = cfg.scan
+        self.spin_key = scan.key
+        self.sweep_ms = int(scan.sweep_ms)
+        self.sweeps = int(scan.sweeps)
+        self.idle_before_scan = float(scan.idle_sec)
+        self.pause_between_sweeps = float(scan.pause)
+        self.scan_enabled = scan.enabled
         if self.scan_enabled:
             # AreaScanner emulates a human turning in place by repeatedly holding the
             # camera‑rotate key.  This reveals monsters that might spawn behind the
@@ -82,7 +85,7 @@ class CycleFarm:
 
         # cooldown slotów
         self.cooldown = {}
-        self.cooldown_min = int(cfg.get("cooldowns", {}).get("slot_min", 10))
+        self.cooldown_min = int(cfg.cooldowns.slot_min)
 
     def stop(self):
         self._stop = True

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 
-from . import get_config
+from . import AgentConfig, get_config
 from .avoid import CollisionAvoid
 from .channel import ChannelSwitcher
 from .detector import ObjectDetector
@@ -42,56 +42,56 @@ class HuntDestroy(AgentStrategy):
         if cfg is not None or window_capture is not None:
             self.setup(cfg, window_capture)
 
-    def setup(self, cfg=None, window_capture=None):
-        cfg = cfg or get_config()
+    def setup(self, cfg: AgentConfig | dict | None = None, window_capture=None):
+        if cfg is None:
+            cfg = get_config()
+        elif isinstance(cfg, dict):
+            cfg = AgentConfig(**cfg)
         self.cfg = cfg
         self.win = window_capture
         self.det = ObjectDetector(
-            cfg["paths"]["model"],
-            cfg["detector"]["classes"],
-            cfg["detector"].get("conf_thr", 0.5),
-            cfg["detector"].get("iou_thr", 0.45),
+            cfg.paths.model,
+            cfg.detector.classes,
+            cfg.detector.conf_thr,
+            cfg.detector.iou_thr,
         )
         self.avoid = CollisionAvoid()
-        dry = cfg.get("dry_run", False)
+        dry = cfg.dry_run
         self.keys = KeyHold(dry=dry, active_fn=getattr(self.win, "is_foreground", None))
-        tdir = cfg["paths"]["templates_dir"]
+        tdir = cfg.paths.templates_dir
         self.teleporter = Teleporter(self.win, tdir, use_ocr=True, dry=dry, cfg=cfg)
-        ch_hotkeys = cfg.get("channel", {}).get("hotkeys")
+        ch_hotkeys = cfg.channel.hotkeys
         self.channel_switcher = ChannelSwitcher(
             self.win, tdir, dry=dry, keys=self.keys, hotkeys=ch_hotkeys
         )
-        self.desired_w = float(cfg.get("policy", {}).get("desired_box_w", 0.12))
-        self.deadzone = float(cfg.get("policy", {}).get("deadzone_x", 0.05))
-        self.priority = cfg.get("priority", ["boss", "metin", "potwory"])
-        scan_cfg = cfg.get("scan", {})
-        self.period = scan_cfg.get("period", 1 / 15)
+        self.desired_w = float(cfg.detector.policy.desired_box_w)
+        self.deadzone = float(cfg.detector.policy.deadzone_x)
+        self.priority = list(cfg.priority)
+        scan_cfg = cfg.scan
+        self.period = scan_cfg.period
         self.scanner = None
-        if scan_cfg.get("enabled", True):
-            rot_key = (
-                cfg.get("controls", {}).get("keys", {}).get("rotate")
-                or cfg.get("controls", {}).get("keys", {}).get("left", "a")
-            )
+        if scan_cfg.enabled:
+            rot_key = cfg.controls.keys.rotate or cfg.controls.keys.left
             self.scanner = AreaScanner(
                 self.keys,
                 spin_key=rot_key,
-                sweep_ms=scan_cfg.get("sweep_ms", 250),
-                sweeps=scan_cfg.get("sweeps", 8),
-                idle_sec=scan_cfg.get("idle_sec", 1.5),
-                pause=scan_cfg.get("pause", 0.12),
+                sweep_ms=scan_cfg.sweep_ms,
+                sweeps=scan_cfg.sweeps,
+                idle_sec=scan_cfg.idle_sec,
+                pause=scan_cfg.pause,
             )
 
-        tp_cfg = cfg.get("teleport", {})
+        tp_cfg = cfg.teleport
         self.search = SearchManager(
             self.teleporter,
             self.channel_switcher,
-            list(tp_cfg.get("slots", [])),
-            tp_cfg.get("page") or tp_cfg.get("page_label"),
-            list(cfg.get("channels", [])),
-            tp_cfg.get("no_target_sec", 10),
-            tp_cfg.get("channel_every", 8),
+            [s.slot for s in tp_cfg.slots],
+            tp_cfg.page or tp_cfg.page_label,
+            list(cfg.channels),
+            tp_cfg.no_target_sec,
+            tp_cfg.channel_every,
         )
-        move_enabled = cfg.get("controls", {}).get("movement", True)
+        move_enabled = cfg.controls.movement
         self.movement = MovementController(
             self.keys, self.desired_w, self.deadzone, enabled=move_enabled
         )

--- a/agent/infer_kbd.py
+++ b/agent/infer_kbd.py
@@ -9,20 +9,23 @@ import torchvision.models as models
 
 from recorder.window_capture import WindowCapture
 
+from . import AgentConfig
 from .model_kbd import KbdPolicy
 from .stuck_flow import FlowStuck
 from .wasd import KeyHold
 
 
 class KbdVisionAgent:
-    def __init__(self, cfg):
-        self.win = WindowCapture(cfg["window"]["title_substr"])
+    def __init__(self, cfg: AgentConfig | dict):
+        if isinstance(cfg, dict):
+            cfg = AgentConfig(**cfg)
+        self.win = WindowCapture(cfg.window.title_substr)
         self.keys = KeyHold()
         self.period = 1 / 15
         self.flow = FlowStuck(
-            cfg.get("stuck", {}).get("flow_window", 0.8),
+            cfg.stuck.flow_window,
             fps=15,
-            min_mag=cfg.get("stuck", {}).get("min_flow_mag", 0.7),
+            min_mag=cfg.stuck.min_flow_mag,
         )
         self.net = KbdPolicy(weights=models.ResNet18_Weights.IMAGENET1K_V1)
         self.net.load_state_dict(

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -11,26 +11,15 @@ from .strategy import load_strategy
 
 
 class WasdVisionAgent:
-    def __init__(self, cfg):
-        """Create a vision agent using ``cfg`` configuration.
+    def __init__(self, cfg: AgentConfig | dict):
+        """Create a vision agent using ``cfg`` configuration."""
 
-        ``cfg`` may be either a raw configuration dictionary or an
-        :class:`agent.AgentConfig` instance.  The teleport slots and channel
-        list are parsed during initialisation so that the user may modify them
-        later through :meth:`set_teleport_slots` and :meth:`set_channels`.
-        """
-
-        if isinstance(cfg, AgentConfig):
-            self.channels = list(cfg.channels)
-            self.teleport_slots = list(cfg.teleport_slots)
-            cfg = cfg.data
-        else:
-            self.channels = list(cfg.get("channels", []))
-            self.teleport_slots = [
-                TeleportSlot(**s) for s in cfg.get("teleport", {}).get("slots", [])
-            ]
+        if isinstance(cfg, dict):
+            cfg = AgentConfig(**cfg)
         self.cfg = cfg
-        self.win = WindowCapture(cfg["window"]["title_substr"])
+        self.channels = list(cfg.channels)
+        self.teleport_slots = list(cfg.teleport.slots)
+        self.win = WindowCapture(cfg.window.title_substr)
         self.period = 1 / 15
         self.hd = None
 
@@ -41,13 +30,13 @@ class WasdVisionAgent:
         """Replace the channel list used by the agent."""
 
         self.channels = list(channels)
-        self.cfg["channels"] = list(channels)
+        self.cfg.channels = list(channels)
 
     def set_teleport_slots(self, slots: list[TeleportSlot]) -> None:
         """Replace the teleport slot definitions."""
 
         self.teleport_slots = list(slots)
-        self.cfg.setdefault("teleport", {})["slots"] = [s.__dict__ for s in slots]
+        self.cfg.teleport.slots = list(slots)
 
     def run(self):
         try:

--- a/agent/strategy.py
+++ b/agent/strategy.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib
-from typing import Protocol, Type, Dict, Callable
+from typing import Callable, Dict, Protocol, Type
+
+from . import AgentConfig
 
 
 class AgentStrategy(Protocol):
@@ -29,14 +31,17 @@ def register(name: str) -> Callable[[Type[AgentStrategy]], Type[AgentStrategy]]:
     return decorator
 
 
-def load_strategy(cfg=None, window_capture=None) -> AgentStrategy:
+def load_strategy(cfg: AgentConfig | dict | None = None, window_capture=None) -> AgentStrategy:
     """Load and instantiate strategy specified in ``cfg``.
 
     The configuration may contain the key ``"strategy"`` naming the desired
     strategy module.  Strategies register themselves via :func:`register`.
     """
 
-    name = (cfg or {}).get("strategy", "hunt_destroy")
+    if isinstance(cfg, AgentConfig):
+        name = cfg.strategy
+    else:
+        name = (cfg or {}).get("strategy", "hunt_destroy")
     if name not in _STRATEGIES:
         importlib.import_module(f"agent.{name}")
     cls = _STRATEGIES.get(name)

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -12,7 +12,7 @@ from PIL import Image
 
 from recorder.window_capture import WindowCapture
 
-from . import get_config
+from . import AgentConfig, get_config
 from .template_matcher import TemplateMatcher
 
 try:  # pragma: no cover - prefer pydirectinput if available
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover - fallback to local implementation
     from .wasd import KeyHold
 
 CFG = get_config()
-pyautogui.PAUSE = CFG.get("controls", {}).get("mouse_pause", 0.02)
+pyautogui.PAUSE = CFG.controls.mouse_pause
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +49,13 @@ class Teleporter:
         templates_dir: str,
         use_ocr: bool = True,
         dry: bool = False,
-        cfg: dict | None = None,
+        cfg: AgentConfig | dict | None = None,
     ):
-        self.cfg = cfg or CFG
+        if cfg is None:
+            cfg = CFG
+        elif isinstance(cfg, dict):
+            cfg = AgentConfig(**cfg)
+        self.cfg = cfg
         self.win = win
         if not os.path.isdir(templates_dir):
             raise FileNotFoundError(f"Brak katalogu z szablonami: {templates_dir}")
@@ -72,14 +76,14 @@ class Teleporter:
         self.keys = KeyHold(
             dry=self.dry, active_fn=getattr(self.win, "is_foreground", None)
         )
-        tp_cfg = self.cfg.get("teleport", {})
-        self.click_duration = tp_cfg.get("click_duration", 0.05)
-        self.open_panel_delay = tp_cfg.get("open_panel_delay", 0.35)
-        self.page_thresh = tp_cfg.get("page_thresh", 0.82)
-        self.after_page_delay = tp_cfg.get("after_page_delay", 0.25)
-        self.row_click_delay = tp_cfg.get("row_click_delay", 0.15)
-        self.load_btn_thresh = tp_cfg.get("load_btn_thresh", 0.8)
-        self.after_load_delay = tp_cfg.get("after_load_delay", 0.35)
+        tp_cfg = self.cfg.teleport
+        self.click_duration = tp_cfg.click_duration
+        self.open_panel_delay = tp_cfg.open_panel_delay
+        self.page_thresh = tp_cfg.page_thresh
+        self.after_page_delay = tp_cfg.after_page_delay
+        self.row_click_delay = tp_cfg.row_click_delay
+        self.load_btn_thresh = tp_cfg.load_btn_thresh
+        self.after_load_delay = tp_cfg.after_load_delay
 
     def _frame(self) -> np.ndarray:
         fr = self.win.grab()
@@ -88,7 +92,7 @@ class Teleporter:
     def _save_panel(self, frame: np.ndarray, reason: TeleportResult) -> None:
         """Save current panel frame for debugging failures."""
         try:
-            log_dir = self.cfg.get("paths", {}).get("log_dir", "runs")
+            log_dir = self.cfg.paths.log_dir or "runs"
             os.makedirs(log_dir, exist_ok=True)
             fname = os.path.join(
                 log_dir, f"tp_fail_{reason.value}_{int(time.time())}.png"

--- a/config/models.py
+++ b/config/models.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class WindowConfig(BaseModel):
+    title_substr: str = "Metin2"
+
+
+class PathsConfig(BaseModel):
+    templates_dir: str = "assets/templates"
+    model: str = "runs/detect/train/weights/best.pt"
+    log_dir: Optional[str] = None
+
+
+class KeyBindings(BaseModel):
+    forward: str = "w"
+    left: str = "a"
+    back: str = "s"
+    right: str = "d"
+    rotate: str = "e"
+
+
+class ControlsConfig(BaseModel):
+    keys: KeyBindings = Field(default_factory=KeyBindings)
+    movement: bool = True
+    key_repeat_ms: int = 60
+    mouse_pause: float = 0.02
+
+
+class DetectorPolicy(BaseModel):
+    deadzone_x: float = 0.05
+    desired_box_w: float = 0.12
+
+
+class DetectorConfig(BaseModel):
+    classes: List[str] = Field(default_factory=lambda: ["metin", "boss", "potwory"])
+    conf_thr: float = 0.5
+    iou_thr: float = 0.45
+    policy: DetectorPolicy = Field(default_factory=DetectorPolicy)
+
+
+class StuckConfig(BaseModel):
+    flow_window: float = 0.8
+    min_flow_mag: float = 0.7
+    rotate_ms_on_stuck: int = 250
+
+
+class ScanConfig(BaseModel):
+    enabled: bool = True
+    period: float = 0.066
+    key: str = "e"
+    sweeps: int = 8
+    sweep_ms: int = 250
+    idle_sec: float = 1.5
+    pause: float = 0.12
+
+
+class CooldownsConfig(BaseModel):
+    slot_min: int = 10
+
+
+class TeleportSlot(BaseModel):
+    page: str
+    slot: int
+
+
+class TeleportConfig(BaseModel):
+    slots: List[TeleportSlot] = Field(default_factory=list)
+    no_target_sec: int = 10
+    channel_every: int = 8
+    click_duration: float = 0.05
+    open_panel_delay: float = 0.35
+    page_thresh: float = 0.82
+    after_page_delay: float = 0.25
+    row_click_delay: float = 0.15
+    load_btn_thresh: float = 0.8
+    after_load_delay: float = 0.35
+    page: Optional[str] = None
+    page_label: Optional[str] = None
+
+
+class ChannelConfig(BaseModel):
+    settle_sec: float = 5.0
+    timeout_per_ch: float = 5.0
+    hotkeys: Dict[int, str] = Field(default_factory=lambda: {i: str(i) for i in range(1, 9)})
+
+
+class CycleConfig(BaseModel):
+    ch_from: int = 1
+    ch_to: int = 8
+    slots: List[int] = Field(default_factory=lambda: list(range(1, 9)))
+    per_spot_sec: float = 90
+    clear_sec: float = 6
+    sequence: List[Dict[str, int]] = Field(default_factory=list)
+
+
+class AgentConfig(BaseModel):
+    strategy: str = "hunt_destroy"
+    window: WindowConfig = Field(default_factory=WindowConfig)
+    paths: PathsConfig = Field(default_factory=PathsConfig)
+    controls: ControlsConfig = Field(default_factory=ControlsConfig)
+    detector: DetectorConfig = Field(default_factory=DetectorConfig)
+    stuck: StuckConfig = Field(default_factory=StuckConfig)
+    scan: ScanConfig = Field(default_factory=ScanConfig)
+    cooldowns: CooldownsConfig = Field(default_factory=CooldownsConfig)
+    priority: List[str] = Field(default_factory=lambda: ["boss", "metin", "potwory"])
+    teleport: TeleportConfig = Field(default_factory=TeleportConfig)
+    channels: List[int] = Field(default_factory=lambda: [1, 2, 3, 4, 5, 6, 7, 8])
+    channel: ChannelConfig = Field(default_factory=ChannelConfig)
+    cycle: CycleConfig = Field(default_factory=CycleConfig)
+    dry_run: bool = False
+
+
+__all__ = [
+    "AgentConfig",
+    "WindowConfig",
+    "PathsConfig",
+    "ControlsConfig",
+    "DetectorConfig",
+    "DetectorPolicy",
+    "StuckConfig",
+    "ScanConfig",
+    "CooldownsConfig",
+    "TeleportConfig",
+    "TeleportSlot",
+    "ChannelConfig",
+    "CycleConfig",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Pillow==11.3.0
 pynput==1.8.1
 keyboard==0.13.5
 pywin32>=306
+pydantic==1.10.15


### PR DESCRIPTION
## Summary
- model agent configuration with Pydantic classes
- load config.yaml as `AgentConfig` and expose via `get_config`
- refactor agents to use typed config objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b69890a2c48330ac9b72033cf2c7e8