### PR TITLE
Add runtime requirement check before GUI launch

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -14,12 +14,14 @@ for parent in ROOT_DIR.parents:
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from PySide6 import QtWidgets
-
 from gui.main_window import MainWindow
+from utils.requirements_check import check_requirements
 
 
 def main() -> None:
+    check_requirements()
+    from PySide6 import QtWidgets
+
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
@@ -28,4 +30,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/utils/requirements_check.py
+++ b/utils/requirements_check.py
@@ -1,0 +1,65 @@
+"""Utilities for verifying that required Python packages are installed.
+
+Reads ``requirements.txt`` and checks installed package versions using
+``importlib.metadata``.  Missing or incompatible packages trigger an attempt to
+install the full requirements file via ``pip``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+
+def check_requirements(requirements_file: Path | None = None) -> None:
+    """Verify installed packages against ``requirements.txt``.
+
+    Parameters
+    ----------
+    requirements_file:
+        Path to the ``requirements.txt`` file.  Defaults to the repository root.
+    """
+
+    if requirements_file is None:
+        requirements_file = Path(__file__).resolve().parents[1] / "requirements.txt"
+
+    if not requirements_file.exists():
+        return
+
+    unmet: list[str] = []
+    for line in requirements_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        req = Requirement(line)
+        try:
+            installed = metadata.version(req.name)
+        except PackageNotFoundError:
+            unmet.append(f"{req.name}{req.specifier}")
+            continue
+
+        if req.specifier and not req.specifier.contains(installed, prereleases=True):
+            unmet.append(f"{req.name} {installed} does not satisfy {req.specifier}")
+
+    if not unmet:
+        return
+
+    print("Unmet dependencies detected:")
+    for item in unmet:
+        print(f" - {item}")
+
+    print("Attempting to install dependencies from requirements.txt...")
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "-r", str(requirements_file)]
+        )
+    except subprocess.CalledProcessError:
+        print(
+            "Automatic installation failed. Please run 'pip install -r requirements.txt' manually."
+        )


### PR DESCRIPTION
## Summary
- add `utils.requirements_check` to verify installed packages against `requirements.txt`
- run requirement check in GUI launcher before importing PySide6

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy'; ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b6c39f046c8330ba793ce73f31e2e4