### PR TITLE
Add minimal GitHub updater to launcher

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -14,12 +14,14 @@ for parent in ROOT_DIR.parents:
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from PySide6 import QtWidgets
-
 from gui.main_window import MainWindow
 
 
 def main() -> None:
+    """Launch the Qt GUI."""
+
+    from PySide6 import QtWidgets
+
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
@@ -28,4 +30,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,25 @@
+"""Entrypoint for launching the GUI with dependency verification."""
+
+from __future__ import annotations
+
+import sys
+
+from utils import check_requirements, update_repository
+
+
+def main() -> None:
+    """Run environment checks then start the GUI application."""
+
+    update_repository()
+
+    if not check_requirements():
+        sys.exit(1)
+
+    from gui.app import main as run_app
+
+    run_app()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility subpackage for runtime helpers."""
+
+from .requirements_check import check_requirements, update_requirements
+from .git_update import update_repository
+
+__all__ = ["check_requirements", "update_requirements", "update_repository"]

--- a/utils/git_update.py
+++ b/utils/git_update.py
@@ -1,0 +1,38 @@
+"""Helpers for updating the local Git repository.
+
+Provides a tiny interface by printing status messages and, if PySide6 is
+available, showing a message box with the result."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _notify(message: str) -> None:
+    """Show ``message`` using a message box when PySide6 is available."""
+    try:
+        from PySide6.QtWidgets import QApplication, QMessageBox
+    except Exception:
+        print(message)
+        return
+
+    app = QApplication.instance() or QApplication([])
+    QMessageBox.information(None, "Updater", message)
+    if not QApplication.instance():
+        app.quit()
+
+
+def update_repository(repo_dir: Path | None = None) -> bool:
+    """Fetch and merge updates from the remote Git repository."""
+    if repo_dir is None:
+        repo_dir = Path(__file__).resolve().parents[1]
+
+    try:
+        print("Checking for updates from GitHub...")
+        subprocess.check_call(["git", "pull", "--ff-only"], cwd=repo_dir)
+        _notify("Repository is up to date.")
+        return True
+    except subprocess.CalledProcessError:
+        _notify("Failed to update repository.")
+        return False

--- a/utils/requirements_check.py
+++ b/utils/requirements_check.py
@@ -1,0 +1,102 @@
+"""Helpers for validating and updating Python dependencies.
+
+The module reads :mod:`requirements.txt` and verifies that installed packages
+match the declared version constraints using :mod:`importlib.metadata`. When a
+package is missing or its version is incompatible, the module can attempt to
+install the needed packages via ``pip``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+
+def update_requirements(
+    requirements: list[Requirement] | None = None,
+    requirements_file: Path | None = None,
+) -> bool:
+    """Install packages using ``pip``.
+
+    Parameters
+    ----------
+    requirements:
+        Specific requirement objects to install. If ``None`` the entire
+        ``requirements.txt`` file is installed.
+    requirements_file:
+        Location of the ``requirements.txt`` file used when ``requirements`` is
+        ``None``. Defaults to the repository root.
+
+    Returns
+    -------
+    bool
+        ``True`` if installation succeeded, otherwise ``False``.
+    """
+
+    if requirements is None:
+        if requirements_file is None:
+            requirements_file = Path(__file__).resolve().parents[1] / "requirements.txt"
+        if not requirements_file.exists():
+            return False
+        cmd = [sys.executable, "-m", "pip", "install", "-r", str(requirements_file)]
+    else:
+        cmd = [sys.executable, "-m", "pip", "install"] + [str(r) for r in requirements]
+
+    try:
+        subprocess.check_call(cmd)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def check_requirements(requirements_file: Path | None = None) -> bool:
+    """Verify installed packages against ``requirements.txt`` and update if needed.
+
+    Returns
+    -------
+    bool
+        ``True`` if all dependencies are satisfied, otherwise ``False``.
+    """
+
+    if requirements_file is None:
+        requirements_file = Path(__file__).resolve().parents[1] / "requirements.txt"
+
+    if not requirements_file.exists():
+        return True
+
+    unmet: list[Requirement] = []
+    for line in requirements_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        req = Requirement(line)
+        try:
+            installed = metadata.version(req.name)
+        except PackageNotFoundError:
+            unmet.append(req)
+            continue
+
+        if req.specifier and not req.specifier.contains(installed, prereleases=True):
+            unmet.append(req)
+
+    if not unmet:
+        return True
+
+    print("Unmet dependencies detected:")
+    for item in unmet:
+        print(f" - {item}")
+
+    print("Attempting to install missing dependencies...")
+    if update_requirements(unmet):
+        return check_requirements(requirements_file)
+
+    print(
+        "Automatic installation failed. Please run 'pip install -r requirements.txt' manually."
+    )
+    return False


### PR DESCRIPTION
## Summary
- add `utils.git_update.update_repository` to pull latest code with small UI
- invoke repository update from `launcher` before dependency checks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b6c39f046c8330ba793ce73f31e2e4