### PR TITLE
Handle unmapped keys with pydirectinput fallback

### DIFF
--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -237,22 +237,28 @@ class KeyHold:
     def _down(self, key: str) -> None:
         if self.dry or (self.active_fn is not None and not self.active_fn()):
             return
-        scan = SCANCODES[key]
-        extended = key in EXTENDED_KEYS
-        if extended:
-            key_down(scan, extended=True)
-        else:
-            key_down(scan)
+        if key in SCANCODES:
+            scan = SCANCODES[key]
+            extended = key in EXTENDED_KEYS
+            if extended:
+                key_down(scan, extended=True)
+            else:
+                key_down(scan)
+        elif pydirectinput is not None:
+            pydirectinput.keyDown(key, _pause=False)
 
     def _up(self, key: str) -> None:
         if self.dry or (self.active_fn is not None and not self.active_fn()):
             return
-        scan = SCANCODES[key]
-        extended = key in EXTENDED_KEYS
-        if extended:
-            key_up(scan, extended=True)
-        else:
-            key_up(scan)
+        if key in SCANCODES:
+            scan = SCANCODES[key]
+            extended = key in EXTENDED_KEYS
+            if extended:
+                key_up(scan, extended=True)
+            else:
+                key_up(scan)
+        elif pydirectinput is not None:
+            pydirectinput.keyUp(key, _pause=False)
 
     def press(self, key: str):
         with self.lock:

--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -10,6 +10,21 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.modules.setdefault("yaml", types.ModuleType("yaml"))
 
+_pydantic = types.ModuleType("pydantic")
+
+
+class _BaseModel:
+    pass
+
+
+def _Field(*args, **kwargs):  # noqa: D401 - simple stub
+    return None
+
+
+_pydantic.BaseModel = _BaseModel
+_pydantic.Field = _Field
+sys.modules.setdefault("pydantic", _pydantic)
+
 import agent.wasd as wasd
 
 
@@ -132,3 +147,16 @@ def test_ctrl_x_combo():
     sc_x = wasd.SCANCODES["x"]
     assert mock_down.call_args_list == [call(sc_ctrl), call(sc_x)]
     assert mock_up.call_args_list == [call(sc_x), call(sc_ctrl)]
+
+
+def test_unknown_key_uses_pydirectinput():
+    """Keys missing from SCANCODES should fall back to pydirectinput."""
+
+    with patch.object(wasd, "pydirectinput") as mock_pdi:
+        kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+        kh.press("q")
+        kh.release("q")
+        kh.stop()
+
+    mock_pdi.keyDown.assert_called_once_with("q", _pause=False)
+    mock_pdi.keyUp.assert_called_once_with("q", _pause=False)


### PR DESCRIPTION
## Summary
- send unmapped keys using pydirectinput in KeyHold
- add regression test for unmapped key fallback

## Testing
- `python -m black agent/wasd.py tests/test_keyhold.py`
- `pytest tests/test_keyhold.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e9b3aef083309c53ac5e21b18288