### PR TITLE
Use KeyHold for teleport actions

### DIFF
--- a/agent/teleport_config.py
+++ b/agent/teleport_config.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple
 
+from .wasd import KeyHold
+
 try:  # pyautogui is optional during tests
     import pyautogui
 except Exception:  # pragma: no cover - provide a tiny stub
@@ -94,6 +96,7 @@ def run_positions(
     *,
     delay: float | None = None,
     close_panel: Callable[[], None] | None = None,
+    keys: KeyHold | None = None,
 ) -> None:
     """Run all configured positions for ``channel``."""
 
@@ -102,12 +105,14 @@ def run_positions(
     if not positions:
         return
 
+    keys = keys or KeyHold()
+
     open_panel()
     time.sleep(cfg.delay_after_panel)
     sleep_delay = delay if delay is not None else cfg.delay_after_teleport
     for x, y in positions:
         pyautogui.click(x, y)
-        pyautogui.press("e")
+        keys.tap("e")
         time.sleep(sleep_delay)
         if close_panel:
             close_panel()

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -225,6 +225,18 @@ class KeyHold:
                 self._up(key)
                 self.down.remove(key)
 
+    def tap(self, key: str, duration: float = 0.05) -> None:
+        """Press and release ``key`` after ``duration`` seconds.
+
+        This helper ensures that both the press and release events are
+        dispatched through :mod:`pydirectinput` by delegating to
+        :meth:`press` and :meth:`release`.
+        """
+
+        self.press(key)
+        time.sleep(duration)
+        self.release(key)
+
     def release_all(self):
         with self.lock:
             if self.down:

--- a/tests/test_teleport_config.py
+++ b/tests/test_teleport_config.py
@@ -39,6 +39,34 @@ def test_main(monkeypatch):
     assert change_calls == [2, 3, 4]
 
 
+def test_run_positions_calls_keys_tap(monkeypatch):
+    class StubKeys:
+        def __init__(self):
+            self.calls = []
+
+        def tap(self, key: str, duration: float = 0.05):
+            self.calls.append((key, duration))
+
+    keys = StubKeys()
+
+    cfg = tc.TeleportRuntimeConfig(
+        {},
+        0.0,
+        1.0,
+        0.0,
+        {1: [(10, 20), (30, 40)]},
+        {},
+    )
+    monkeypatch.setattr(tc, "get_config", lambda path="config/teleport.yaml": cfg)
+    monkeypatch.setattr(tc.pyautogui, "click", lambda x, y: None)
+    monkeypatch.setattr(tc.time, "sleep", lambda s: None)
+    monkeypatch.setattr(tc, "open_panel", lambda: None)
+
+    tc.run_positions(1, keys=keys)
+
+    assert keys.calls == [("e", 0.05), ("e", 0.05)]
+
+
 def test_save_teleport_config(tmp_path, monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- add KeyHold.tap for short press via pydirectinput
- let teleport_config run_positions use KeyHold to press teleport key
- test run_positions invokes tap for each configured position

## Testing
- `pytest tests/test_keyhold.py tests/test_teleport_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b723b2f4c48330bcb02f635de24243