### PR TITLE
Use KeyHold for Teleporter.close_panel

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -210,7 +210,7 @@ class Teleporter:
         """Close the teleport panel if it is open."""
         if self.dry:
             return
-        pyautogui.press("esc")
+        self.keys.tap("esc")
 
     def go_page(self, page_label: str, thresh: float | None = None) -> bool:
         token = page_label.split()[-1].upper().replace(" ", "_")

--- a/tests/test_teleport_close_panel.py
+++ b/tests/test_teleport_close_panel.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import types
+from unittest.mock import Mock
+
+# Ensure repository root on path and stub optional dependencies
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub yaml so configuration loading succeeds without dependency
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda f: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
+# Minimal pydantic stub providing BaseModel and Field
+_pydantic = types.ModuleType("pydantic")
+
+class _BaseModel:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+def _Field(default=None, default_factory=None, **kwargs):
+    if default_factory is not None:
+        return default_factory()
+    return default
+
+_pydantic.BaseModel = _BaseModel
+_pydantic.Field = _Field
+sys.modules.setdefault("pydantic", _pydantic)
+
+# Stub easyocr to avoid heavy import
+sys.modules.setdefault("easyocr", types.SimpleNamespace(Reader=lambda *a, **k: None))
+
+# Provide a minimal numpy stub for imports
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
+# Stub PIL.Image used for saving screenshots
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+
+# Stub pyautogui to avoid real key presses
+pyautogui_stub = types.SimpleNamespace(
+    moveTo=lambda *a, **k: None,
+    click=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+    locateOnScreen=lambda *a, **k: None,
+    PAUSE=0,
+)
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+# Stub recorder.window_capture
+recorder_pkg = types.ModuleType("recorder")
+recorder_pkg.__path__ = []
+wc_mod = types.ModuleType("recorder.window_capture")
+
+class WindowCapture:
+    pass
+
+wc_mod.WindowCapture = WindowCapture
+recorder_pkg.window_capture = wc_mod
+sys.modules.setdefault("recorder", recorder_pkg)
+sys.modules.setdefault("recorder.window_capture", wc_mod)
+
+# Stub agent.template_matcher used during import
+tm_stub = types.ModuleType("agent.template_matcher")
+
+class _TM:
+    def __init__(self, *a, **k):
+        pass
+
+tm_stub.TemplateMatcher = _TM
+sys.modules.setdefault("agent.template_matcher", tm_stub)
+
+from agent.teleport import Teleporter
+
+
+def test_close_panel_taps_esc_on_keys():
+    teleporter = Teleporter.__new__(Teleporter)
+    teleporter.dry = False
+    mock_keys = Mock()
+    teleporter.keys = mock_keys
+
+    teleporter.close_panel()
+
+    mock_keys.tap.assert_called_once_with("esc")


### PR DESCRIPTION
## Summary
- use KeyHold.tap to close the teleport panel
- add regression test for Teleporter.close_panel using injected KeyHold

## Testing
- `pytest tests/test_teleport_close_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68b724e9184483309195d5c0dde6711e