### PR TITLE
Add tap helper and tests for KeyHold

### DIFF
--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -228,9 +228,8 @@ class KeyHold:
     def tap(self, key: str, duration: float = 0.05) -> None:
         """Press and release ``key`` after ``duration`` seconds.
 
-        This helper ensures that both the press and release events are
-        dispatched through :mod:`pydirectinput` by delegating to
-        :meth:`press` and :meth:`release`.
+        This convenience wrapper depends on :mod:`pydirectinput` to emit the
+        keyboard events by delegating to :meth:`press` and :meth:`release`.
         """
 
         self.press(key)

--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -175,3 +175,17 @@ def test_unknown_key_uses_pydirectinput():
 
     mock_pdi.keyDown.assert_called_once_with("q", _pause=False)
     mock_pdi.keyUp.assert_called_once_with("q", _pause=False)
+
+
+def test_tap_uses_pydirectinput():
+    """``tap`` should press and release keys via ``pydirectinput``."""
+
+    with patch.object(wasd, "pydirectinput") as mock_pdi, patch.object(
+        wasd.time, "sleep", return_value=None
+    ):
+        kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+        kh.tap("q")
+        kh.stop()
+
+    mock_pdi.keyDown.assert_called_once_with("q", _pause=False)
+    mock_pdi.keyUp.assert_called_once_with("q", _pause=False)


### PR DESCRIPTION
## Summary
- document and expose `KeyHold.tap` for pydirectinput
- test `tap` dispatches keyDown/keyUp via pydirectinput

## Testing
- `pytest tests/test_keyhold.py`


------
https://chatgpt.com/codex/tasks/task_e_68b725d3acb8833094251b9452537fa3