### PR TITLE
Handle missing teleport template

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -254,7 +254,12 @@ class Teleporter:
 
         logger.debug("Teleporting to slot %s on page '%s'", slot, page_label)
         # otwórz panel i przejdź do strony
-        self.open_panel()
+        try:
+            self.open_panel()
+        except RuntimeError:
+            frame = self._frame()
+            self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
+            return TeleportResult.TEMPLATE_NOT_FOUND
         if not self.win.is_foreground():
             return TeleportResult.WINDOW_NOT_FOREGROUND
         if not self.go_page(page_label):


### PR DESCRIPTION
## Summary
- gracefully handle missing teleport panel templates in `teleport_slot`

## Testing
- `pytest tests/test_teleport_close_panel.py -q`
- `pytest -q` *(fails: AttributeError: '_DummyTeleporter' object has no attribute 'close_panel')*


------
https://chatgpt.com/codex/tasks/task_e_68b726f4d7048330ba7b9129b53ae22f