### PR TITLE
Use logging instead of print in utilities

### DIFF
--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import utils.git_update as git_update
+import utils.requirements_check as req_check
+
+
+def test_update_repository_logs(monkeypatch, caplog, tmp_path):
+    def fake_check_call(cmd, cwd=None):
+        return 0
+
+    monkeypatch.setattr(git_update.subprocess, "check_call", fake_check_call)
+    caplog.set_level(logging.INFO)
+    assert git_update.update_repository(repo_dir=tmp_path)
+    assert "Checking for updates from GitHub..." in caplog.text
+    assert "Repository is up to date." in caplog.text
+
+
+def test_check_requirements_logs(monkeypatch, caplog, tmp_path):
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("nonexistent-package==0\n")
+
+    monkeypatch.setattr(req_check, "update_requirements", lambda reqs: False)
+    caplog.set_level(logging.INFO)
+
+    result = req_check.check_requirements(req_file)
+    assert result is False
+    log_text = caplog.text
+    assert "Unmet dependencies detected:" in log_text
+    assert "Attempting to install missing dependencies..." in log_text
+    assert "Automatic installation failed." in log_text
+

--- a/utils/git_update.py
+++ b/utils/git_update.py
@@ -1,20 +1,25 @@
 """Helpers for updating the local Git repository.
 
-Provides a tiny interface by printing status messages and, if PySide6 is
+Provides a tiny interface by logging status messages and, if PySide6 is
 available, showing a message box with the result."""
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
 
-def _notify(message: str) -> None:
+def _notify(message: str, level: int = logging.INFO) -> None:
     """Show ``message`` using a message box when PySide6 is available."""
     try:
         from PySide6.QtWidgets import QApplication, QMessageBox
     except Exception:
-        print(message)
+        if level == logging.ERROR:
+            logger.error(message)
+        else:
+            logger.info(message)
         return
 
     app = QApplication.instance() or QApplication([])
@@ -29,10 +34,10 @@ def update_repository(repo_dir: Path | None = None) -> bool:
         repo_dir = Path(__file__).resolve().parents[1]
 
     try:
-        print("Checking for updates from GitHub...")
+        logger.info("Checking for updates from GitHub...")
         subprocess.check_call(["git", "pull", "--ff-only"], cwd=repo_dir)
         _notify("Repository is up to date.")
         return True
     except subprocess.CalledProcessError:
-        _notify("Failed to update repository.")
+        _notify("Failed to update repository.", level=logging.ERROR)
         return False

--- a/utils/requirements_check.py
+++ b/utils/requirements_check.py
@@ -8,6 +8,7 @@ install the needed packages via ``pip``.
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import sys
 from importlib import metadata
@@ -15,6 +16,8 @@ from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 from packaging.requirements import Requirement
+
+logger = logging.getLogger(__name__)
 
 
 def update_requirements(
@@ -88,15 +91,15 @@ def check_requirements(requirements_file: Path | None = None) -> bool:
     if not unmet:
         return True
 
-    print("Unmet dependencies detected:")
+    logger.error("Unmet dependencies detected:")
     for item in unmet:
-        print(f" - {item}")
+        logger.error(" - %s", item)
 
-    print("Attempting to install missing dependencies...")
+    logger.info("Attempting to install missing dependencies...")
     if update_requirements(unmet):
         return check_requirements(requirements_file)
 
-    print(
+    logger.error(
         "Automatic installation failed. Please run 'pip install -r requirements.txt' manually."
     )
     return False


### PR DESCRIPTION
## Summary
- add module-level loggers to git and requirements utilities
- log messages rather than printing to stdout
- cover logging behaviour with tests

## Testing
- `pytest tests/test_utils_logging.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b7289e3d708330836c27a9757ee715