### PR TITLE
Configure pyautogui pause per Teleporter

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -21,7 +21,6 @@ except Exception:  # pragma: no cover - fallback to local implementation
     from .wasd import KeyHold
 
 CFG = get_config()
-pyautogui.PAUSE = CFG.controls.mouse_pause
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +55,7 @@ class Teleporter:
         elif isinstance(cfg, dict):
             cfg = AgentConfig(**cfg)
         self.cfg = cfg
+        pyautogui.PAUSE = self.cfg.controls.mouse_pause
         self.win = win
         if not os.path.isdir(templates_dir):
             raise FileNotFoundError(f"Brak katalogu z szablonami: {templates_dir}")

--- a/tests/test_channel_switcher.py
+++ b/tests/test_channel_switcher.py
@@ -16,7 +16,7 @@ sys.modules.setdefault("yaml", types.ModuleType("yaml"))
 
 # Stub pyautogui to avoid real mouse interaction
 pyautogui_stub = types.SimpleNamespace(
-    moveTo=lambda *a, **k: None, click=lambda *a, **k: None
+    moveTo=lambda *a, **k: None, click=lambda *a, **k: None, PAUSE=0
 )
 sys.modules.setdefault("pyautogui", pyautogui_stub)
 

--- a/tests/test_cycle_sequence.py
+++ b/tests/test_cycle_sequence.py
@@ -8,7 +8,7 @@ def test_cycle_sequence(monkeypatch):
 
     # Stub optional dependencies before importing agent modules.
     sys.modules.setdefault("ultralytics", types.SimpleNamespace(YOLO=object))
-    sys.modules.setdefault("pyautogui", types.SimpleNamespace())
+    sys.modules.setdefault("pyautogui", types.SimpleNamespace(PAUSE=0))
     sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: None))
     sys.modules.setdefault("pygetwindow", types.SimpleNamespace(getAllWindows=lambda: []))
     sys.modules.setdefault("win32con", types.SimpleNamespace())

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 # Stub pyautogui so interaction module can be imported without the real dependency
 pyautogui_stub = types.SimpleNamespace(
-    moveTo=lambda *a, **k: None, click=lambda *a, **k: None
+    moveTo=lambda *a, **k: None, click=lambda *a, **k: None, PAUSE=0
 )
 sys.modules.setdefault("pyautogui", pyautogui_stub)
 sys.modules.setdefault("yaml", types.ModuleType("yaml"))

--- a/tests/test_teleport_close_panel.py
+++ b/tests/test_teleport_close_panel.py
@@ -72,6 +72,7 @@ class _TM:
 tm_stub.TemplateMatcher = _TM
 sys.modules.setdefault("agent.template_matcher", tm_stub)
 
+sys.modules.pop("agent.teleport", None)
 from agent.teleport import Teleporter
 
 

--- a/tests/test_teleport_config.py
+++ b/tests/test_teleport_config.py
@@ -6,6 +6,7 @@ import types
 pyautogui_stub = types.ModuleType("pyautogui")
 pyautogui_stub.click = lambda *a, **k: None
 pyautogui_stub.press = lambda *a, **k: None
+pyautogui_stub.PAUSE = 0
 sys.modules.setdefault("pyautogui", pyautogui_stub)
 
 yaml_stub = types.ModuleType("yaml")


### PR DESCRIPTION
## Summary
- Remove global pyautogui pause assignment
- Set `pyautogui.PAUSE` from config inside `Teleporter.__init__`
- Stub tests explicitly with `pyautogui.PAUSE = 0` to avoid relying on global state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b728a035308330a007422f5729667d