### PR TITLE
docs: translate Polish docstrings to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ keyboard listener relies on a low‑level hook provided by the
   permissions.
 
 If the hook cannot be installed only mouse clicks will be recorded.
+
+## Contributing
+
+Documentation and in‑code comments should be written in **English**. Polish
+clarifications may be kept as inline comments when helpful, but the primary
+docstrings and README content must remain in English.

--- a/agent/avoid.py
+++ b/agent/avoid.py
@@ -5,7 +5,10 @@ import numpy as np
 
 
 class CollisionAvoid:
-    """Ekranowe unikanie kolizji: krawędzie + przepływ w centralnym pasku."""
+    """Screen-space collision avoidance using edges and flow in the central band.
+
+    PL: Ekranowe unikanie kolizji: krawędzie + przepływ w centralnym pasku.
+    """
 
     def __init__(
         self,

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -18,7 +18,13 @@ logger = logging.getLogger(__name__)
 
 
 class CycleFarm:
-    """
+    """8×8 cycle: slots 1..8 × CH(ch_from..ch_to).
+
+    On each slot: teleport → hunt (with auto scan 'E').
+    No target → short 'E' scan; still none → next slot.
+    Slots have cooldown (minutes) to avoid immediate return.
+
+    PL:
     Cykl 8×8: sloty 1..8 × CH(ch_from..ch_to).
     Na każdym slocie: teleport -> poluj (z autoskanem 'E').
     Brak celu -> krótki skan E; nadal brak -> kolejny slot.
@@ -107,7 +113,10 @@ class CycleFarm:
 
     # ---- logika pojedynczego slotu ----
     def _process_slot(self, ch, slot, page_label, per_spot_sec, clear_sec):
-        """Obsłuż teleportację i polowanie na pojedynczym slocie."""
+        """Handle teleportation and hunting on a single slot.
+
+        PL: Obsłuż teleportację i polowanie na pojedynczym slocie.
+        """
 
         now = time.time()
         key = (ch, slot)
@@ -173,28 +182,35 @@ class CycleFarm:
         clear_sec,
         sequence=None,
     ):
-        """Główna pętla cyklu farmienia.
+        """Main farming cycle loop.
 
+        ``sequence`` specifies the full order of channel/slot visits. Each
+        element should be a two‑element iterable ``(ch, slot)`` or a dict with
+        keys ``ch`` and ``slot``. When ``sequence`` is provided the parameters
+        ``ch_from``, ``ch_to`` and ``slots`` are ignored.
+
+        Parameters
+        ----------
+        page_label: str
+            Teleport page label.
+        ch_from, ch_to: int
+            Range of channels to visit cyclically.
+        slots: Iterable[int]
+            Collection of slot numbers to visit.
+        per_spot_sec: float
+            Maximum time to hunt on a single spot.
+        clear_sec: float
+            Time without a target after which the spot is considered clear.
+        sequence: Iterable
+            Optional full sequence of ``(channel, slot)`` pairs.
+
+        PL:
+        Główna pętla cyklu farmienia.
         "sequence" pozwala określić pełną kolejność odwiedzania kanałów i
         slotów.  Każdy element listy powinien być dwuelementowym iterowalnym
         (ch, slot) lub słownikiem z kluczami ``ch`` i ``slot``.  Gdy sekwencja
         jest podana, parametry ``ch_from``, ``ch_to`` oraz ``slots`` są
         ignorowane.
-
-        Parameters
-        ----------
-        page_label: str
-            Etykieta strony teleportu.
-        ch_from, ch_to: int
-            Zakres kanałów do cyklicznego odwiedzenia.
-        slots: Iterable[int]
-            Kolekcja numerów slotów do odwiedzenia.
-        per_spot_sec: float
-            Maksymalny czas polowania na jednym spocie.
-        clear_sec: float
-            Czas bez celu po którym uznajemy spot za czysty.
-        sequence: Iterable
-            Opcjonalna pełna sekwencja (kanał, slot).
         """
 
         if sequence:

--- a/agent/detector.py
+++ b/agent/detector.py
@@ -12,7 +12,13 @@ cv2.setNumThreads(1)
 
 
 class ObjectDetector:
-    """Lekka nakładka na Ultralytics YOLO do detekcji na klatce BGR (numpy array).
+    """Lightweight wrapper around Ultralytics YOLO for detection on BGR frames.
+
+    Additionally allows limiting detection frequency and dynamically
+    scaling input resolution to reduce CPU/GPU load.
+
+    PL:
+    Lekka nakładka na Ultralytics YOLO do detekcji na klatce BGR (numpy array).
 
     Dodatkowo umożliwia ograniczenie częstotliwości detekcji oraz
     dynamiczne skalowanie rozdzielczości wejściowej w celu redukcji

--- a/agent/interaction.py
+++ b/agent/interaction.py
@@ -26,21 +26,23 @@ def _rate_limit_ok() -> bool:
 def click_bbox_center(
     bbox, region, rate_limit: bool = True, win: WindowCapture | None = None
 ) -> bool:
-    """Kliknij w środek ``bbox`` w obrębie ``region`` jeśli okno jest aktywne.
+    """Click the centre of ``bbox`` within ``region`` if the window is active.
 
     Parameters
     ----------
     bbox, region: tuple
-        Współrzędne celu i obszaru w jakim się znajduje.
+        Target and region coordinates.
     rate_limit: bool
-        Czy stosować ograniczenie liczby klików na sekundę.
+        Whether to limit the number of clicks per second.
     win: WindowCapture | None
-        Opcjonalna instancja okna pozwalająca sprawdzić fokus.
+        Optional window instance used to verify focus.
 
     Returns
     -------
     bool
-        ``True`` jeśli kliknięcie zostało wykonane.
+        ``True`` if the click was performed.
+
+    PL: Kliknij w środek ``bbox`` w obrębie ``region`` jeśli okno jest aktywne.
     """
 
     x1, y1, x2, y2 = bbox
@@ -61,7 +63,10 @@ def click_bbox_center(
 
 
 def burst_click(bbox, region, n=3, interval=0.08, win: WindowCapture | None = None):
-    """Seria kliknięć w ``bbox`` z zachowaniem bezpieczeństwa fokusu."""
+    """Series of clicks within ``bbox`` while ensuring window focus.
+
+    PL: Seria kliknięć w ``bbox`` z zachowaniem bezpieczeństwa fokusu.
+    """
     for _ in range(n):
         if not click_bbox_center(bbox, region, rate_limit=False, win=win):
             break

--- a/agent/model.py
+++ b/agent/model.py
@@ -4,7 +4,13 @@ import numpy as np
 
 
 class ClickPolicy:
-    """Prosty model zwracający zerowe przewidywania.
+    """Simple model returning zero predictions.
+
+    In this test implementation we avoid PyTorch; instead we operate on
+    ``numpy`` arrays and return matrices of the appropriate shapes.
+
+    PL:
+    Prosty model zwracający zerowe przewidywania.
 
     W implementacji testowej nie używamy PyTorcha; zamiast tego działamy na
     tablicach ``numpy`` i zwracamy macierze o odpowiednich kształtach.

--- a/agent/model_kbd.py
+++ b/agent/model_kbd.py
@@ -4,7 +4,13 @@ import numpy as np
 
 
 class KbdPolicy:
-    """Prosty model zwracający prawdopodobieństwa klawiszy WASD.
+    """Simple model returning probabilities for WASD keys.
+
+    Returns a zero matrix of shape ``(B, 4)`` corresponding to ``W``, "A",
+    "S" and "D".
+
+    PL:
+    Prosty model zwracający prawdopodobieństwa klawiszy WASD.
 
     Zwraca macierz zer o kształcie ``(B, 4)`` odpowiadającą klawiszom
     ``W``, ``A``, ``S`` i ``D``.

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -34,7 +34,15 @@ class TeleportResult(Enum):
 
 
 class Teleporter:
-    """
+    """Teleport panel helper.
+
+    - ``open_panel()``: Ctrl+X (with focus)
+    - ``go_page('Page I'..'Page VIII')``
+    - ``teleport(point, page)``
+    - ``teleport_slot(slot, page)``: scroll + retry, click "Load"
+    Requires templates: ``wczytaj.png``, ``strona_I.png``..``strona_VIII.png``
+
+    PL:
     Panel teleportu:
     - open_panel(): Ctrl+X (z focusem)
     - go_page('Strona I'..'Strona VIII')
@@ -245,12 +253,21 @@ class Teleporter:
 
     # ---- teleportacja ----
     def teleport_slot(self, slot: int, page_label: str) -> TeleportResult:
-        """Teleportuj do danego numeru slotu na podanej stronie.
+        """Teleport to ``slot`` on ``page_label``.
+
+        Returns :class:`TeleportResult` describing the outcome of the
+        attempt. On failure a screenshot of the panel is saved to
+        ``runs/`` (or the directory specified by ``paths.log_dir`` in the
+        configuration).
+
+        PL:
+        Teleportuj do danego numeru slotu na podanej stronie.
 
         Zwraca :class:`TeleportResult` opisujący rezultat próby
         teleportacji.  Przy niepowodzeniu zrzut panelu jest zapisywany w
         ``runs/`` (lub w katalogu wskazanym przez ``paths.log_dir`` w
-        konfiguracji)."""
+        konfiguracji).
+        """
 
         logger.debug("Teleporting to slot %s on page '%s'", slot, page_label)
         # otwórz panel i przejdź do strony
@@ -303,5 +320,8 @@ class Teleporter:
         return TeleportResult.OK
 
     def teleport(self, slot: int, page_label: str) -> TeleportResult:
-        """Zachowana dla kompatybilności nazwa ``teleport``."""
+        """Compatibility wrapper named ``teleport``.
+
+        PL: Zachowana dla kompatybilności nazwa ``teleport``.
+        """
         return self.teleport_slot(slot, page_label)

--- a/agent/template_matcher.py
+++ b/agent/template_matcher.py
@@ -98,7 +98,10 @@ class TemplateMatcher:
         scales=(1.0, 0.9, 1.1, 0.8),
         dedup_px=12,
     ):
-        """Zwraca listę dopasowań (:class:`TemplateMatch`) posortowanych po Y (od góry)."""
+        """Return a list of matches (:class:`TemplateMatch`) sorted by Y (top to bottom).
+
+        PL: Zwraca listę dopasowań (:class:`TemplateMatch`) posortowanych po Y (od góry).
+        """
         gray, offx, offy = self._prep(frame_bgr, roi)
         tpl0 = self.load(name)
         found: list[TemplateMatch] = []

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -155,7 +155,17 @@ def key_up(scan: int, extended: bool = False) -> None:
 
 class KeyHold:
     def __init__(self, dry: bool = False, active_fn=None):
-        """
+        """Key press helper with optional window activity check.
+
+        Parameters
+        ----------
+        dry : bool, default ``False``
+            If ``True`` do not send real key events (test mode).
+        active_fn : callable or None
+            Zero‑argument function returning ``True`` when the window is
+            active. When ``False`` the watchdog releases all keys.
+
+        PL:
         dry: jeśli True – nie wysyła realnych klawiszy (tryb testowy)
         active_fn: funkcja bezargumentowa -> bool (czy okno jest aktywne). Gdy False, watchdog zwalnia klawisze.
         """


### PR DESCRIPTION
## Summary
- Translate Polish docstrings across agent modules to English while keeping Polish notes
- Add contributing note requiring English documentation

## Testing
- `pytest` *(fails: AttributeError: '_DummyTeleporter' object has no attribute 'close_panel')*


------
https://chatgpt.com/codex/tasks/task_e_68b728a0d9f0833091d7c09505d50fb2