### PR TITLE
Ensure teleport panel detection checks all pages

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -119,15 +119,16 @@ class Teleporter:
         pyautogui.moveTo(x, y, duration=self.click_duration)
         pyautogui.click()
 
-    def open_panel(self, max_attempts: int = 3, ref_name: str = "strona_I") -> bool:
+    def open_panel(self, max_attempts: int = 3) -> bool:
         """Open teleport panel and verify it appears.
 
-        Sends the ``Ctrl+X`` hotkey, takes a screenshot and checks whether a
-        reference template is visible.  The check is performed first with
+        Sends the ``Ctrl+X`` hotkey, takes a screenshot and checks whether any
+        of the page templates (``strona_I.png`` .. ``strona_VIII.png``) is
+        visible.  For each template the check is performed first with
         :class:`TemplateMatcher` and then, if needed, with
-        :func:`pyautogui.locateOnScreen`.  When the panel is not detected the
-        hotkey is retried ``max_attempts`` times before raising
-        :class:`RuntimeError`.
+        :func:`pyautogui.locateOnScreen`.  The function returns as soon as a
+        template matches.  When the panel is not detected the hotkey is retried
+        ``max_attempts`` times before raising :class:`RuntimeError`.
         """
 
         self.win.focus()
@@ -143,13 +144,15 @@ class Teleporter:
             int(h * 0.16),
         )
         screen_roi = (L + roi[0], T + roi[1], roi[2], roi[3])
-        template_path = self.tm.dir / f"{ref_name}.png"
+        page_refs = [
+            f"strona_{r}" for r in ["I", "II", "III", "IV", "V", "VI", "VII", "VIII"]
+        ]
         logger.debug(
-            "open_panel setup: region=%s ROI=%s screen_roi=%s template=%s thresh=%.3f",
+            "open_panel setup: region=%s ROI=%s screen_roi=%s templates=%s thresh=%.3f",
             self.win.region,
             roi,
             screen_roi,
-            template_path,
+            page_refs,
             self.page_thresh,
         )
 
@@ -176,37 +179,46 @@ class Teleporter:
                     "Window lost foreground after keypress on attempt %d", attempt + 1
                 )
 
-            found = self.tm.find(
-                frame,
-                ref_name,
-                thresh=self.page_thresh,
-                roi=roi,
-                multi_scale=True,
-            )
-            if found:
-                logger.debug("TemplateMatcher result: %s", found)
-            else:
-                logger.debug(
-                    "TemplateMatcher did not find panel; falling back to pyautogui.locateOnScreen"
+            found = None
+            for ref_name in page_refs:
+                template_path = self.tm.dir / f"{ref_name}.png"
+                found = self.tm.find(
+                    frame,
+                    ref_name,
+                    thresh=self.page_thresh,
+                    roi=roi,
+                    multi_scale=True,
                 )
-
-            if not found:
+                if found:
+                    logger.debug(
+                        "TemplateMatcher found %s on attempt %d", ref_name, attempt + 1
+                    )
+                    return True
+                logger.debug(
+                    "TemplateMatcher did not find %s; falling back to pyautogui.locateOnScreen",
+                    ref_name,
+                )
                 try:
                     found = pyautogui.locateOnScreen(
                         str(template_path),
                         region=screen_roi,
                         confidence=self.page_thresh,
                     )
-                    logger.debug("pyautogui.locateOnScreen result: %s", found)
+                    logger.debug(
+                        "pyautogui.locateOnScreen result for %s: %s", ref_name, found
+                    )
                 except Exception:
                     logger.debug(
-                        "pyautogui.locateOnScreen raised exception", exc_info=True
+                        "pyautogui.locateOnScreen raised exception for %s", ref_name, exc_info=True
                     )
                     found = None
-
-            if found:
-                logger.debug("Teleport panel detected on attempt %d", attempt + 1)
-                return True
+                if found:
+                    logger.debug(
+                        "Teleport panel detected via pyautogui for %s on attempt %d",
+                        ref_name,
+                        attempt + 1,
+                    )
+                    return True
             logger.debug("Teleport panel not detected on attempt %d", attempt + 1)
 
         logger.warning("Teleport panel not detected after %d attempts", max_attempts)

--- a/tests/test_teleport_open_panel.py
+++ b/tests/test_teleport_open_panel.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+# Ensure repository root on path and stub optional dependencies
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub yaml so configuration loading succeeds without dependency
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda f: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
+# Minimal pydantic stub providing BaseModel and Field
+_pydantic = types.ModuleType("pydantic")
+
+class _BaseModel:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+def _Field(default=None, default_factory=None, **kwargs):
+    if default_factory is not None:
+        return default_factory()
+    return default
+
+_pydantic.BaseModel = _BaseModel
+_pydantic.Field = _Field
+sys.modules.setdefault("pydantic", _pydantic)
+
+# Stub easyocr to avoid heavy import
+sys.modules.setdefault("easyocr", types.SimpleNamespace(Reader=lambda *a, **k: None))
+
+# Provide a minimal numpy stub for imports
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
+# Stub PIL.Image used for saving screenshots
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+
+# Stub pyautogui to avoid real key presses
+pyautogui_stub = types.SimpleNamespace(
+    moveTo=lambda *a, **k: None,
+    click=lambda *a, **k: None,
+    press=lambda *a, **k: None,
+    locateOnScreen=lambda *a, **k: None,
+    PAUSE=0,
+)
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+# Stub recorder.window_capture
+recorder_pkg = types.ModuleType("recorder")
+recorder_pkg.__path__ = []
+wc_mod = types.ModuleType("recorder.window_capture")
+
+class WindowCapture:
+    pass
+
+wc_mod.WindowCapture = WindowCapture
+recorder_pkg.window_capture = wc_mod
+sys.modules.setdefault("recorder", recorder_pkg)
+sys.modules.setdefault("recorder.window_capture", wc_mod)
+
+# Stub agent.template_matcher used during import
+tm_stub = types.ModuleType("agent.template_matcher")
+
+class _TM:
+    def __init__(self, *a, **k):
+        pass
+
+tm_stub.TemplateMatcher = _TM
+sys.modules.setdefault("agent.template_matcher", tm_stub)
+
+sys.modules.pop("agent.teleport", None)
+from agent.teleport import Teleporter
+
+
+def test_open_panel_detects_non_first_page():
+    teleporter = Teleporter.__new__(Teleporter)
+    teleporter.dry = False
+    teleporter.keys = types.SimpleNamespace(
+        press=lambda *a, **k: None,
+        release=lambda *a, **k: None,
+    )
+    teleporter.open_panel_delay = 0
+    teleporter.page_thresh = 0.5
+    teleporter.win = types.SimpleNamespace(
+        focus=lambda: None,
+        is_foreground=lambda: True,
+        region=(0, 0, 100, 100),
+    )
+    teleporter._frame = lambda: types.SimpleNamespace(shape=(1, 1, 3))
+
+    call_order = []
+
+    class TM:
+        dir = Path(".")
+
+        def find(self, frame, name, thresh, roi, multi_scale):
+            call_order.append(name)
+            if name == "strona_II":
+                return object()
+            return None
+
+    teleporter.tm = TM()
+
+    assert teleporter.open_panel() is True
+    assert call_order[:2] == ["strona_I", "strona_II"]


### PR DESCRIPTION
## Summary
- Update `Teleporter.open_panel` to search for teleport templates across all pages, returning success when any page template is found and falling back to `pyautogui.locateOnScreen` for each
- Add regression test covering detection when starting on a non-`Strona I` page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7db28d43483309242c4c4b2e55699