### PR TITLE
Add hotkey helper for teleport panel

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -162,10 +162,7 @@ class Teleporter:
                 logger.debug("Window not in foreground on attempt %d", attempt + 1)
             logger.debug("Attempt %d to open teleport panel", attempt + 1)
             if not self.dry:
-                self.keys.press("ctrl")
-                self.keys.press("x")
-                self.keys.release("x")
-                self.keys.release("ctrl")
+                self.keys.hotkey(["ctrl", "x"], duration=0.05)
             else:
                 return True
             time.sleep(self.open_panel_delay)

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -246,6 +246,19 @@ class KeyHold:
         time.sleep(duration)
         self.release(key)
 
+    def hotkey(self, keys: list[str], duration: float = 0.05) -> None:
+        """Press ``keys`` together and hold for ``duration`` seconds.
+
+        Keys are pressed in the provided order and released in reverse order
+        after a short sleep so that the combination is reliably registered.
+        """
+
+        for k in keys:
+            self.press(k)
+        time.sleep(duration)
+        for k in reversed(keys):
+            self.release(k)
+
     def release_all(self):
         with self.lock:
             if self.down:

--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -8,7 +8,9 @@ import pytest
 # Make repository root importable and provide a stub ``yaml`` module so that the
 # :mod:`agent` package can be imported without optional dependencies.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda f: {}
+sys.modules.setdefault("yaml", yaml_stub)
 
 _pydantic = types.ModuleType("pydantic")
 
@@ -189,3 +191,20 @@ def test_tap_uses_pydirectinput():
 
     mock_pdi.keyDown.assert_called_once_with("q", _pause=False)
     mock_pdi.keyUp.assert_called_once_with("q", _pause=False)
+
+
+def test_hotkey_holds_keys_for_duration():
+    """``hotkey`` should press keys, wait, then release in reverse order."""
+
+    kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+    kh.stop()
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up, patch.object(wasd.time, "sleep", return_value=None) as mock_sleep:
+        kh.hotkey(["ctrl", "x"], duration=0.1)
+
+    sc_ctrl = wasd.SCANCODES["ctrl"]
+    sc_x = wasd.SCANCODES["x"]
+    assert mock_down.call_args_list == [call(sc_ctrl), call(sc_x)]
+    assert mock_sleep.call_args_list == [call(0.1)]
+    assert mock_up.call_args_list == [call(sc_x), call(sc_ctrl)]

--- a/tests/test_teleport_open_panel.py
+++ b/tests/test_teleport_open_panel.py
@@ -79,10 +79,12 @@ from agent.teleport import Teleporter
 def test_open_panel_detects_non_first_page():
     teleporter = Teleporter.__new__(Teleporter)
     teleporter.dry = False
-    teleporter.keys = types.SimpleNamespace(
-        press=lambda *a, **k: None,
-        release=lambda *a, **k: None,
-    )
+    hotkey_calls: list[tuple[list[str], float]] = []
+
+    def _hotkey(keys, duration=0.05):
+        hotkey_calls.append((keys, duration))
+
+    teleporter.keys = types.SimpleNamespace(hotkey=_hotkey)
     teleporter.open_panel_delay = 0
     teleporter.page_thresh = 0.5
     teleporter.win = types.SimpleNamespace(
@@ -106,4 +108,5 @@ def test_open_panel_detects_non_first_page():
     teleporter.tm = TM()
 
     assert teleporter.open_panel() is True
+    assert hotkey_calls == [(["ctrl", "x"], 0.05)]
     assert call_order[:2] == ["strona_I", "strona_II"]


### PR DESCRIPTION
## Summary
- add `KeyHold.hotkey` for pressing key combinations with a hold duration
- use the new helper in `Teleporter.open_panel` with a short 0.05s delay
- expand unit tests for `KeyHold.hotkey` and ensure teleport panel uses it

## Testing
- `pytest tests/test_channel_switcher.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/test_keyhold.py tests/test_teleport_open_panel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7dc3f60408330bf9d0829339499ad