### PR TITLE
feat: run area scans in background threads

### DIFF
--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 
 import numpy as np
 
@@ -39,6 +40,7 @@ class HuntDestroy(AgentStrategy):
         self.movement = None
         self._last_tgt = None
         self._prev_names: set[str] = set()
+        self._grab_lock = threading.Lock()
         if cfg is not None or window_capture is not None:
             self.setup(cfg, window_capture)
 
@@ -100,7 +102,8 @@ class HuntDestroy(AgentStrategy):
         self._prev_names = set()
 
     def step(self):
-        fr = self.win.grab()
+        with self._grab_lock:
+            fr = self.win.grab()
         frame = np.array(fr)[:, :, :3].copy()
         H, W = frame.shape[:2]
         dets = self.det.infer(frame)
@@ -118,14 +121,22 @@ class HuntDestroy(AgentStrategy):
         if tgt is None:
             logger.debug("Brak celu w zasięgu")
             if self.scanner:
-                self.scanner.scan()
-                self.search.handle_no_target(True)
+                if self.scanner.is_scanning():
+                    self.search.handle_no_target(False)
+                else:
+                    if self.scanner.is_done():
+                        self.search.handle_no_target(True)
+                        self.scanner.reset()
+                    else:
+                        self.scanner.scan()
                 self._last_tgt = None
                 return
             self._last_tgt = None
             return
 
         self.search.update_last_target()
+        if self.scanner and self.scanner.is_scanning():
+            self.scanner.cancel()
 
         bw = None
         if tgt:

--- a/agent/scanner.py
+++ b/agent/scanner.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import threading
 import time
+from typing import Callable, Optional
 
 from .wasd import KeyHold
 
@@ -30,21 +32,74 @@ class AreaScanner:
         self.idle_sec = idle_sec
         self.pause = pause
 
-    def scan(self) -> None:
-        """Perform the scan by slowly rotating the camera.
+        # internal state for asynchronous operation
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._completed = False
+        self._progress = 0
+        self._progress_cb: Optional[Callable[[float], None]] = None
 
-        ``sweep_ms`` controls how long the spin key is held which translates
-        roughly into the angle of rotation.  After ``sweeps`` iterations the
-        character has usually completed a full 360° turn.
-        """
+    # ------------------------------------------------------------------
+    # threading helpers
+    def _run(self) -> None:
+        """Worker method executed in a background thread."""
 
-        # Allow the game to settle before starting the rotation, otherwise
-        # the first frames may still show the previous teleport location.
+        # Allow the game to settle before starting the rotation
         time.sleep(self.idle_sec)
-        for _ in range(self.sweeps):
+        for i in range(self.sweeps):
+            if self._stop.is_set():
+                break
             self.keys.press(self.spin_key)
             time.sleep(self.sweep_ms / 1000.0)
             self.keys.release(self.spin_key)
-            # Small pause between sweeps ensures the key tap is registered and
-            # gives the detector time to process the new view.
+            self._progress = (i + 1) / float(self.sweeps)
+            if self._progress_cb:
+                try:
+                    self._progress_cb(self._progress)
+                except Exception:
+                    pass
             time.sleep(self.pause)
+        else:
+            # loop did not break -> full scan completed
+            self._completed = True
+
+    def scan(self, progress_cb: Optional[Callable[[float], None]] = None) -> None:
+        """Start an asynchronous scan.
+
+        Parameters
+        ----------
+        progress_cb: callable or None
+            Callback invoked with a float in the ``0..1`` range each time a
+            sweep is completed.
+        """
+
+        if self.is_scanning():
+            return
+        self._progress_cb = progress_cb
+        self._progress = 0
+        self._completed = False
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def cancel(self) -> None:
+        """Cancel the running scan if any."""
+
+        self._stop.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=0)
+
+    def is_scanning(self) -> bool:
+        return bool(self._thread and self._thread.is_alive())
+
+    def progress(self) -> float:
+        return self._progress
+
+    def is_done(self) -> bool:
+        return self._completed and not self.is_scanning()
+
+    def reset(self) -> None:
+        """Reset completion flag so a new scan can begin."""
+
+        self._completed = False
+        self._progress = 0

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -84,20 +84,25 @@ class _StubKeyHold:
         self.down = set()
         self.pressed = []
         self.released = []
+        self.lock = __import__("threading").Lock()
 
     def press(self, key):
-        if key not in self.down:
-            self.down.add(key)
-            self.pressed.append(key)
+        with self.lock:
+            if key not in self.down:
+                self.down.add(key)
+                self.pressed.append(key)
 
     def release(self, key):
-        if key in self.down:
-            self.down.remove(key)
-            self.released.append(key)
+        with self.lock:
+            if key in self.down:
+                self.down.remove(key)
+                self.released.append(key)
 
     def release_all(self):
-        for k in list(self.down):
-            self.release(k)
+        with self.lock:
+            for k in list(self.down):
+                self.down.remove(k)
+                self.released.append(k)
 
     def stop(self):
         pass
@@ -132,9 +137,11 @@ class _EmptyDetector:
 class _StubSearch:
     def __init__(self, *a, **k):
         self.calls = 0
+        self.spin_done_values = []
 
     def handle_no_target(self, spin_done):
         self.calls += 1
+        self.spin_done_values.append(spin_done)
 
     def update_last_target(self):
         pass
@@ -195,11 +202,25 @@ def test_scan_no_target(monkeypatch):
             self.keys = keys
             self.spin_key = spin_key
             self.calls = 0
+            self._scanning = False
+            self._done = False
 
-        def scan(self):
+        def scan(self, progress_cb=None):
             self.calls += 1
+            self._scanning = True
             self.keys.press(self.spin_key)
             self.keys.release(self.spin_key)
+            self._scanning = False
+            self._done = True
+
+        def is_scanning(self):
+            return self._scanning
+
+        def is_done(self):
+            return self._done
+
+        def reset(self):
+            self._done = False
 
     monkeypatch.setattr(hd, "AreaScanner", _StubScanner)
 
@@ -211,9 +232,59 @@ def test_scan_no_target(monkeypatch):
     }
     agent = hd.HuntDestroy(cfg, _DummyWin())
 
-    agent.step()
+    agent.step()  # start scan
     assert agent.scanner.calls == 1
+    assert agent.search.calls == 0
+
+    agent.step()  # handle completed scan
     assert agent.search.calls == 1
     assert agent.keys.down == set()
     assert agent.keys.pressed == [agent.scanner.spin_key]
     assert agent.keys.released == [agent.scanner.spin_key]
+
+
+def test_scan_interrupt_on_target(monkeypatch):
+    monkeypatch.setattr(hd, "CollisionAvoid", lambda: _DummyAvoid())
+    monkeypatch.setattr(hd, "KeyHold", _StubKeyHold)
+    monkeypatch.setattr(hd, "SearchManager", _StubSearch)
+    monkeypatch.setattr(hd, "pick_target", _pick_target)
+    monkeypatch.setattr(hd, "click_bbox_center", lambda *a, **k: None)
+
+    class _Detector:
+        def __init__(self, *a, **k):
+            self.calls = 0
+
+        def infer(self, frame):
+            self.calls += 1
+            if self.calls < 3:
+                return []
+            return [{"name": "enemy", "bbox": (10, 10, 20, 20)}]
+
+    monkeypatch.setattr(hd, "ObjectDetector", _Detector)
+
+    cfg = {
+        "paths": {"model": "", "templates_dir": ""},
+        "detector": {"classes": [], "conf_thr": 0.5, "iou_thr": 0.5},
+        "policy": {"desired_box_w": 0.2, "deadzone_x": 0.1},
+        "dry_run": True,
+        "scan": {"enabled": True, "sweep_ms": 1, "sweeps": 50, "idle_sec": 0, "pause": 0.001},
+    }
+
+    agent = hd.HuntDestroy(cfg, _DummyWin())
+
+    agent.step()  # start scan
+    assert agent.scanner.is_scanning()
+
+    agent.step()  # still scanning, no target
+    assert agent.scanner.is_scanning()
+
+    agent.step()  # target appears
+    # wait briefly for scan thread to react to cancellation
+    import time as _t
+    for _ in range(100):
+        if not agent.scanner.is_scanning():
+            break
+        _t.sleep(0.01)
+    assert not agent.scanner.is_scanning()
+    assert agent.search.calls == 1
+    assert agent.search.spin_done_values == [False]


### PR DESCRIPTION
## Summary
- run AreaScanner rotation loop in a background thread and report progress
- use non-blocking scan in HuntDestroy; keep grabbing frames while scanning and cancel when a target appears
- add tests for scanning without targets and interrupting scans when targets appear

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e386cf20833082a71859e0f8a7ed