### PR TITLE
Use hotkey for channel switching

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -178,10 +178,8 @@ class ChannelSwitcher:
             if key:
                 if not self._ensure_active_window():
                     return False
-                self.keys.press("ctrl")
-                self.keys.press(key)
-                self.keys.release(key)
-                self.keys.release("ctrl")
+                # Hold the Ctrl+<number> hotkey briefly to ensure it registers
+                self.keys.hotkey(["ctrl", key], duration=0.05)
                 if post_wait:
                     time.sleep(post_wait)
                 return True

--- a/tests/test_channel_switcher.py
+++ b/tests/test_channel_switcher.py
@@ -12,7 +12,9 @@ np = importlib.import_module("numpy")
 
 # Ensure repository root on path and stub optional dependencies
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda f: {}
+sys.modules.setdefault("yaml", yaml_stub)
 
 # Stub pyautogui to avoid real mouse interaction
 pyautogui_stub = types.SimpleNamespace(
@@ -83,10 +85,7 @@ class DummyWin:
 
 
 class KH:
-    def press(self, key):
-        pass
-
-    def release(self, key):
+    def hotkey(self, keys, duration=0.05):
         pass
 
 
@@ -173,15 +172,12 @@ def test_switch_uses_keys_when_not_found(tmp_path, monkeypatch):
 
     monkeypatch.setattr(channel, "TemplateMatcher", TM)
 
-    presses = []
+    hotkey_calls: list[tuple[list[str], float]] = []
     focuses = []
 
     class KH:
-        def press(self, key):
-            presses.append(f"down-{key}")
-
-        def release(self, key):
-            presses.append(f"up-{key}")
+        def hotkey(self, keys, duration=0.05):
+            hotkey_calls.append((keys, duration))
 
     class Win(DummyWin):
         def focus(self):
@@ -189,7 +185,7 @@ def test_switch_uses_keys_when_not_found(tmp_path, monkeypatch):
 
     cs = channel.ChannelSwitcher(Win(), str(tmp_path), dry=False, keys=KH())
     assert cs.switch(3, tries=1, post_wait=0) is True
-    assert presses == ["down-ctrl", "down-3", "up-3", "up-ctrl"]
+    assert hotkey_calls == [(["ctrl", "3"], 0.05)]
     assert focuses, "focus should be called before sending keys"
 
 

--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -208,3 +208,21 @@ def test_hotkey_holds_keys_for_duration():
     assert mock_down.call_args_list == [call(sc_ctrl), call(sc_x)]
     assert mock_sleep.call_args_list == [call(0.1)]
     assert mock_up.call_args_list == [call(sc_x), call(sc_ctrl)]
+
+
+@pytest.mark.parametrize("num", list("12345678"))
+def test_hotkey_ctrl_number_combo(num):
+    """Hotkey should handle Ctrl+1..8 combinations with a delay."""
+
+    kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+    kh.stop()
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up, patch.object(wasd.time, "sleep", return_value=None) as mock_sleep:
+        kh.hotkey(["ctrl", num], duration=0.1)
+
+    sc_ctrl = wasd.SCANCODES["ctrl"]
+    sc_num = wasd.SCANCODES[num]
+    assert mock_down.call_args_list == [call(sc_ctrl), call(sc_num)]
+    assert mock_sleep.call_args_list == [call(0.1)]
+    assert mock_up.call_args_list == [call(sc_num), call(sc_ctrl)]


### PR DESCRIPTION
## Summary
- send Ctrl+number as a single hotkey when falling back to keyboard channel switching
- test ChannelSwitcher uses the hotkey helper
- add KeyHold hotkey test for Ctrl+1..8 combinations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e5cc6a1c8330889ae32a395f506b