### PR TITLE
feat: use numpad hotkeys for channel switching

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -59,7 +59,8 @@ class ChannelSwitcher:
             keys = KeyHold(dry=dry, active_fn=getattr(win, "is_foreground", None))
 
         self.keys = keys
-        self.hotkeys = hotkeys or {i: str(i) for i in range(1, 9)}
+        # Default to numeric keypad hotkeys (``numpad1`` … ``numpad8``)
+        self.hotkeys = hotkeys or {i: f"numpad{i}" for i in range(1, 9)}
 
     def _ensure_active_window(self) -> bool:
         """Ensure the game window is focused and in the foreground.
@@ -178,10 +179,8 @@ class ChannelSwitcher:
             if key:
                 if not self._ensure_active_window():
                     return False
-                self.keys.press("ctrl")
-                self.keys.press(key)
-                self.keys.release(key)
-                self.keys.release("ctrl")
+                # Hold the channel hotkey briefly to ensure it registers
+                self.keys.hotkey([key], duration=0.05)
                 if post_wait:
                     time.sleep(post_wait)
                 return True

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -56,7 +56,7 @@ SCANCODES = {
     "shift": 0x2A,
     "ctrl": 0x1D,
     "alt": 0x38,
-    # Hotkeys for teleport (Ctrl+X) and channel switching (Ctrl+1..8)
+    # Hotkey for teleport (Ctrl+X); channel switching uses NumPad1..8
     "x": 0x2D,
     "1": 0x02,
     "2": 0x03,
@@ -66,6 +66,15 @@ SCANCODES = {
     "6": 0x07,
     "7": 0x08,
     "8": 0x09,
+    # Numeric keypad keys allow configuring channel hotkeys to e.g. ``numpad1``
+    "numpad1": 0x4F,
+    "numpad2": 0x50,
+    "numpad3": 0x51,
+    "numpad4": 0x4B,
+    "numpad5": 0x4C,
+    "numpad6": 0x4D,
+    "numpad7": 0x47,
+    "numpad8": 0x48,
     "up": 0x48,
     "down": 0x50,
     "left": 0x4B,
@@ -88,7 +97,7 @@ VK_CODES = {
     "shift": 0x10,
     "ctrl": 0x11,
     "alt": 0x12,
-    # Hotkeys for teleport (Ctrl+X) and channel switching (Ctrl+1..8)
+    # Hotkey for teleport (Ctrl+X); channel switching uses NumPad1..8
     "x": 0x58,
     "1": 0x31,
     "2": 0x32,
@@ -98,6 +107,15 @@ VK_CODES = {
     "6": 0x36,
     "7": 0x37,
     "8": 0x38,
+    # Numeric keypad virtual key codes
+    "numpad1": 0x61,
+    "numpad2": 0x62,
+    "numpad3": 0x63,
+    "numpad4": 0x64,
+    "numpad5": 0x65,
+    "numpad6": 0x66,
+    "numpad7": 0x67,
+    "numpad8": 0x68,
     "up": 0x26,
     "down": 0x28,
     "left": 0x25,

--- a/config/models.py
+++ b/config/models.py
@@ -85,7 +85,9 @@ class TeleportConfig(BaseModel):
 class ChannelConfig(BaseModel):
     settle_sec: float = 5.0
     timeout_per_ch: float = 5.0
-    hotkeys: Dict[int, str] = Field(default_factory=lambda: {i: str(i) for i in range(1, 9)})
+    hotkeys: Dict[int, str] = Field(
+        default_factory=lambda: {i: f"numpad{i}" for i in range(1, 9)}
+    )
 
 
 class CycleConfig(BaseModel):

--- a/gui/i18n/en.ts
+++ b/gui/i18n/en.ts
@@ -143,7 +143,7 @@
     <message>
         <location filename="../main_window.py" line="209"/>
         <location filename="../main_window.py" line="472"/>
-        <source>Skróty kanałów (Ctrl + klawisz):</source>
+        <source>Skróty kanałów (klawisze numpada):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/i18n/pl.ts
+++ b/gui/i18n/pl.ts
@@ -143,7 +143,7 @@
     <message>
         <location filename="../main_window.py" line="209"/>
         <location filename="../main_window.py" line="472"/>
-        <source>Skróty kanałów (Ctrl + klawisz):</source>
+        <source>Skróty kanałów (klawisze numpada):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -580,14 +580,14 @@ class MainWindow(QtWidgets.QMainWindow):
         ch_layout = QtWidgets.QVBoxLayout(self.ch_box)
         self.ch_shortcuts_label = QtWidgets.QLabel(
             QtCore.QCoreApplication.translate(
-                "MainWindow", "Skróty kanałów (Ctrl + klawisz):"
+                "MainWindow", "Skróty kanałów (klawisze numpada):"
             )
         )
         ch_layout.addWidget(self.ch_shortcuts_label)
         self.ch_key_edits = {}
         ch_form = QtWidgets.QFormLayout()
         for i in range(1, 9):
-            edit = QtWidgets.QLineEdit(str(i))
+            edit = QtWidgets.QLineEdit(f"numpad{i}")
             edit.setMaximumWidth(40)
             self.ch_key_edits[i] = edit
             ch_form.addRow(
@@ -965,7 +965,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.ch_shortcuts_label.setText(
             QtCore.QCoreApplication.translate(
-                "MainWindow", "Skróty kanałów (Ctrl + klawisz):"
+                "MainWindow", "Skróty kanałów (klawisze numpada):"
             )
         )
         for i in range(1, 9):
@@ -1212,7 +1212,8 @@ class MainWindow(QtWidgets.QMainWindow):
         classes = [c.strip() for c in self.classes_edit.text().split(",") if c.strip()]
         prio = self.current_priority()
         hotkeys = {
-            i: self.ch_key_edits[i].text().strip() or str(i) for i in range(1, 9)
+            i: self.ch_key_edits[i].text().strip() or f"numpad{i}"
+            for i in range(1, 9)
         }
         cfg = {
             "window": {"title_substr": title},
@@ -1346,7 +1347,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.tp_minutes.setValue(int(tp.get("minutes", 10)))
         ch_hot = cfg.get("channel", {}).get("hotkeys", {})
         for i in range(1, 9):
-            key = ch_hot.get(str(i)) or ch_hot.get(i) or str(i)
+            key = ch_hot.get(str(i)) or ch_hot.get(i) or f"numpad{i}"
             self.ch_key_edits[i].setText(key)
 
         seq = cfg.get("cycle", {}).get("sequence", [])

--- a/tests/test_channel_switcher.py
+++ b/tests/test_channel_switcher.py
@@ -12,7 +12,9 @@ np = importlib.import_module("numpy")
 
 # Ensure repository root on path and stub optional dependencies
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda f: {}
+sys.modules.setdefault("yaml", yaml_stub)
 
 # Stub pyautogui to avoid real mouse interaction
 pyautogui_stub = types.SimpleNamespace(
@@ -83,10 +85,7 @@ class DummyWin:
 
 
 class KH:
-    def press(self, key):
-        pass
-
-    def release(self, key):
+    def hotkey(self, keys, duration=0.05):
         pass
 
 
@@ -173,15 +172,12 @@ def test_switch_uses_keys_when_not_found(tmp_path, monkeypatch):
 
     monkeypatch.setattr(channel, "TemplateMatcher", TM)
 
-    presses = []
+    hotkey_calls: list[tuple[list[str], float]] = []
     focuses = []
 
     class KH:
-        def press(self, key):
-            presses.append(f"down-{key}")
-
-        def release(self, key):
-            presses.append(f"up-{key}")
+        def hotkey(self, keys, duration=0.05):
+            hotkey_calls.append((keys, duration))
 
     class Win(DummyWin):
         def focus(self):
@@ -189,8 +185,34 @@ def test_switch_uses_keys_when_not_found(tmp_path, monkeypatch):
 
     cs = channel.ChannelSwitcher(Win(), str(tmp_path), dry=False, keys=KH())
     assert cs.switch(3, tries=1, post_wait=0) is True
-    assert presses == ["down-ctrl", "down-3", "up-3", "up-ctrl"]
+    assert hotkey_calls == [(["numpad3"], 0.05)]
     assert focuses, "focus should be called before sending keys"
+
+
+def test_custom_hotkeys_respected(tmp_path, monkeypatch):
+    _setup_templates(tmp_path)
+
+    class TM:
+        def __init__(self, *a, **k):
+            pass
+
+        def find(self, frame, name, **kw):
+            return None
+
+    monkeypatch.setattr(channel, "TemplateMatcher", TM)
+
+    hotkey_calls: list[tuple[list[str], float]] = []
+
+    class KH:
+        def hotkey(self, keys, duration=0.05):
+            hotkey_calls.append((keys, duration))
+
+    custom = {i: str(i) for i in range(1, 9)}
+    cs = channel.ChannelSwitcher(
+        DummyWin(), str(tmp_path), dry=False, keys=KH(), hotkeys=custom
+    )
+    assert cs.switch(2, tries=1, post_wait=0) is True
+    assert hotkey_calls == [(["2"], 0.05)]
 
 
 def test_next_wraps(tmp_path):
@@ -243,4 +265,4 @@ def test_cycle_until_target_seen(tmp_path, monkeypatch):
 def test_default_hotkeys_mapping(tmp_path):
     _setup_templates(tmp_path)
     cs = channel.ChannelSwitcher(DummyWin(), str(tmp_path), dry=True, keys=KH())
-    assert cs.hotkeys == {i: str(i) for i in range(1, 9)}
+    assert cs.hotkeys == {i: f"numpad{i}" for i in range(1, 9)}

--- a/tests/test_keyhold.py
+++ b/tests/test_keyhold.py
@@ -147,6 +147,20 @@ def test_ctrl_number_combo(num):
     assert mock_up.call_args_list == [call(sc_num), call(sc_ctrl)]
 
 
+@pytest.mark.parametrize("key", [f"numpad{i}" for i in range(1, 9)])
+def test_press_release_numpad_calls_sendinput(key):
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up:
+        kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+        kh.press(key)
+        kh.release(key)
+        kh.stop()
+
+    mock_down.assert_called_once_with(wasd.SCANCODES[key])
+    mock_up.assert_called_once_with(wasd.SCANCODES[key])
+
+
 def test_ctrl_x_combo():
     """Ctrl+X hotkey should be emitted correctly."""
 
@@ -208,3 +222,56 @@ def test_hotkey_holds_keys_for_duration():
     assert mock_down.call_args_list == [call(sc_ctrl), call(sc_x)]
     assert mock_sleep.call_args_list == [call(0.1)]
     assert mock_up.call_args_list == [call(sc_x), call(sc_ctrl)]
+
+
+@pytest.mark.parametrize("num", list("12345678"))
+def test_hotkey_ctrl_number_combo(num):
+    """Hotkey should handle Ctrl+1..8 combinations with a delay."""
+
+    kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+    kh.stop()
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up, patch.object(wasd.time, "sleep", return_value=None) as mock_sleep:
+        kh.hotkey(["ctrl", num], duration=0.1)
+
+    sc_ctrl = wasd.SCANCODES["ctrl"]
+    sc_num = wasd.SCANCODES[num]
+    assert mock_down.call_args_list == [call(sc_ctrl), call(sc_num)]
+    assert mock_sleep.call_args_list == [call(0.1)]
+    assert mock_up.call_args_list == [call(sc_num), call(sc_ctrl)]
+
+
+@pytest.mark.parametrize("num", [f"numpad{i}" for i in range(1, 9)])
+def test_hotkey_ctrl_numpad_combo(num):
+    """Hotkey should handle Ctrl+NumPad1..8 combinations with a delay."""
+
+    kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+    kh.stop()
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up, patch.object(wasd.time, "sleep", return_value=None) as mock_sleep:
+        kh.hotkey(["ctrl", num], duration=0.1)
+
+    sc_ctrl = wasd.SCANCODES["ctrl"]
+    sc_num = wasd.SCANCODES[num]
+    assert mock_down.call_args_list == [call(sc_ctrl), call(sc_num)]
+    assert mock_sleep.call_args_list == [call(0.1)]
+    assert mock_up.call_args_list == [call(sc_num), call(sc_ctrl)]
+
+
+@pytest.mark.parametrize("key", [f"numpad{i}" for i in range(1, 9)])
+def test_hotkey_single_numpad(key):
+    """Hotkey should handle single NumPad keys with a delay."""
+
+    kh = wasd.KeyHold(dry=False, active_fn=lambda: True)
+    kh.stop()
+    with patch.object(wasd, "key_down") as mock_down, patch.object(
+        wasd, "key_up"
+    ) as mock_up, patch.object(wasd.time, "sleep", return_value=None) as mock_sleep:
+        kh.hotkey([key], duration=0.1)
+
+    sc = wasd.SCANCODES[key]
+    assert mock_down.call_args_list == [call(sc)]
+    assert mock_sleep.call_args_list == [call(0.1)]
+    assert mock_up.call_args_list == [call(sc)]


### PR DESCRIPTION
## Summary
- map channel switching to configurable numpad keys instead of Ctrl+number
- allow GUI configuration of channel hotkeys with numpad defaults
- test KeyHold hotkey support for single numpad keys

## Testing
- `pytest tests/test_keyhold.py tests/test_channel_switcher.py tests/test_teleport_open_panel.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e5cc6a1c8330889ae32a395f506b