### PR TITLE
Fix channel switcher indentation

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -156,14 +156,14 @@ class ChannelSwitcher:
             raise ValueError("Kanał poza zakresem 1..8")
         if not self.keys:
             return False
-          
+
         key = self.hotkeys.get(ch)
         if not key:
             return False
 
         self.win.focus()
-        
-                if not self._ensure_active_window():
+
+        if not self._ensure_active_window():
             return False
 
         # Hold the channel hotkey briefly to ensure it registers


### PR DESCRIPTION
## Summary
- fix indentation in ChannelSwitcher.switch to properly call `_ensure_active_window`

## Testing
- `python -m pytest`
- `flake8 agent/channel.py`
- `make lint` *(fails: tests/test_channel_switcher.py:190:5: F841 local variable 'hotkey_calls' is assigned to but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b8093840908330901e94aa63ac1a16