### PR TITLE
Add channel cycling helper and cursor positioning for teleport clicks

### DIFF
--- a/agent/teleport_config.py
+++ b/agent/teleport_config.py
@@ -116,7 +116,8 @@ def run_positions(
     time.sleep(cfg.delay_after_panel)
     sleep_delay = delay if delay is not None else cfg.delay_after_teleport
     for x, y in positions:
-        pyautogui.click(x, y)
+        pyautogui.moveTo(x, y)
+        pyautogui.click(button="left")
         keys.tap("e")
         time.sleep(sleep_delay)
         if close_panel:
@@ -135,11 +136,17 @@ def change_channel(target_ch: int, *, delay: float | None = None) -> None:
     time.sleep(delay if delay is not None else cfg.delay_after_channel)
 
 
-def main() -> None:  # pragma: no cover - helper script
-    for ch in [1, 2, 3, 4]:
+def cycle_channels(channels: list[int]) -> None:
+    """Run positions for each channel and switch between them."""
+
+    for idx, ch in enumerate(channels):
         run_positions(ch)
-        if ch < 4:
-            change_channel(ch + 1)
+        if idx + 1 < len(channels):
+            change_channel(channels[idx + 1])
+
+
+def main() -> None:  # pragma: no cover - helper script
+    cycle_channels([1, 2, 3, 4])
 
 
 __all__ = [

--- a/config/teleport.yaml
+++ b/config/teleport.yaml
@@ -1,5 +1,5 @@
 delay_after_panel: 0.5
-delay_after_teleport: 1.0
+delay_after_teleport: 6.0
 delay_after_channel: 5.0
 positions_by_channel:
   1:

--- a/tests/test_teleport_config.py
+++ b/tests/test_teleport_config.py
@@ -5,6 +5,7 @@ import types
 
 pyautogui_stub = types.ModuleType("pyautogui")
 pyautogui_stub.click = lambda *a, **k: None
+pyautogui_stub.moveTo = lambda *a, **k: None
 pyautogui_stub.press = lambda *a, **k: None
 pyautogui_stub.PAUSE = 0
 sys.modules.setdefault("pyautogui", pyautogui_stub)
@@ -31,13 +32,10 @@ def test_change_channel(monkeypatch):
 
 
 def test_main(monkeypatch):
-    run_calls = []
-    change_calls = []
-    monkeypatch.setattr(tc, "run_positions", lambda ch: run_calls.append(ch))
-    monkeypatch.setattr(tc, "change_channel", lambda ch: change_calls.append(ch))
+    calls = []
+    monkeypatch.setattr(tc, "cycle_channels", lambda chs: calls.append(chs))
     tc.main()
-    assert run_calls == [1, 2, 3, 4]
-    assert change_calls == [2, 3, 4]
+    assert calls == [[1, 2, 3, 4]]
 
 
 def test_run_positions_calls_keys_tap(monkeypatch):
@@ -59,7 +57,8 @@ def test_run_positions_calls_keys_tap(monkeypatch):
         {},
     )
     monkeypatch.setattr(tc, "get_config", lambda path="config/teleport.yaml": cfg)
-    monkeypatch.setattr(tc.pyautogui, "click", lambda x, y: None)
+    monkeypatch.setattr(tc.pyautogui, "moveTo", lambda x, y: None)
+    monkeypatch.setattr(tc.pyautogui, "click", lambda *a, **k: None)
     monkeypatch.setattr(tc.time, "sleep", lambda s: None)
     monkeypatch.setattr(tc, "open_panel", lambda: None)
 
@@ -103,3 +102,13 @@ def test_get_config_reload(tmp_path, monkeypatch):
     data["delay_after_panel"] = 2.0
     cfg2 = tc.get_config(path)
     assert cfg2.delay_after_panel == 2.0
+
+
+def test_cycle_channels(monkeypatch):
+    run_calls = []
+    change_calls = []
+    monkeypatch.setattr(tc, "run_positions", lambda ch: run_calls.append(ch))
+    monkeypatch.setattr(tc, "change_channel", lambda ch: change_calls.append(ch))
+    tc.cycle_channels([1, 2, 3])
+    assert run_calls == [1, 2, 3]
+    assert change_calls == [2, 3]


### PR DESCRIPTION
## Summary
- move cursor to stored coordinates before teleport clicks and tap rotation
- add `cycle_channels` helper and update `main` to use it
- increase default teleport delay to 6s for target scan

## Testing
- `pip install -q numpy pydantic pyyaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81c35f04c8330a8685377cddfae61