### PR TITLE
Ensure channel switch moves cursor before clicking

### DIFF
--- a/agent/teleport_config.py
+++ b/agent/teleport_config.py
@@ -132,7 +132,8 @@ def change_channel(target_ch: int, *, delay: float | None = None) -> None:
     if not coords:
         return
     x, y = coords
-    pyautogui.click(x, y)
+    pyautogui.moveTo(x, y)
+    pyautogui.click(button="left")
     time.sleep(delay if delay is not None else cfg.delay_after_channel)
 
 

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -10,7 +10,9 @@ pyautogui_stub = types.SimpleNamespace(
     moveTo=lambda *a, **k: None, click=lambda *a, **k: None, PAUSE=0
 )
 sys.modules.setdefault("pyautogui", pyautogui_stub)
-sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda *a, **k: {}
+sys.modules.setdefault("yaml", yaml_stub)
 
 import agent.interaction as interaction
 

--- a/tests/test_teleport_config.py
+++ b/tests/test_teleport_config.py
@@ -25,10 +25,15 @@ def test_change_channel(monkeypatch):
 
     cfg = tc.TeleportRuntimeConfig({}, 0.0, 0.0, 5.0, [], {2: (10, 20)})
     monkeypatch.setattr(tc, "get_config", lambda path="config/teleport.yaml": cfg)
-    monkeypatch.setattr(tc.pyautogui, "click", lambda x, y: calls.append((x, y)))
+    monkeypatch.setattr(
+        tc.pyautogui, "moveTo", lambda x, y: calls.append(("move", x, y))
+    )
+    monkeypatch.setattr(
+        tc.pyautogui, "click", lambda *a, **k: calls.append(("click", k.get("button")))
+    )
     monkeypatch.setattr(tc.time, "sleep", lambda s: calls.append(s))
     tc.change_channel(2)
-    assert calls == [(10, 20), 5.0]
+    assert calls == [("move", 10, 20), ("click", "left"), 5.0]
 
 
 def test_main(monkeypatch):


### PR DESCRIPTION
## Summary
- Move mouse to channel switch coordinates before clicking
- Adjust tests to reflect cursor movement
- Stabilize test stubs for YAML dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9260658908330b743d00f8961f783