### PR TITLE
Add YOLO label assistant tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ python training/train_yolo.py --data path/to/data.yaml --model yolov8n.pt --epoc
 ```
 The script saves results under `runs/detect/train` by default. Adjust epochs, image size or device as needed.
 
+## Dataset Tools
+Utilities in the [`tools/`](tools) folder help build training datasets.
+
+### Extract Frames
+Save every ``n``‑th frame from gameplay recordings:
+```bash
+python tools/extract_frames.py --rec-dir data/recordings --out-dir datasets/mt2/images/train --step 15
+```
+
+### Label Assistant
+Generate YOLO labels from model predictions.  In interactive mode press ``Y`` or ``Space`` to accept detections for an image, any other key skips it:
+```bash
+python tools/label_assistant.py \
+  --model runs/detect/train/weights/best.pt \
+  --images datasets/mt2/images/train \
+  --labels datasets/mt2/labels/train \
+  --confidence 0.3 \
+  --interactive
+```
+
 ## Running
 ### GUI
 Launch the control panel with real‑time preview and training utilities:

--- a/tools/label_assistant.py
+++ b/tools/label_assistant.py
@@ -1,0 +1,105 @@
+"""Semi-automatic labeling assistant using a YOLO model.
+
+This utility iterates over all images in a folder, runs a YOLO detector
+on each and writes the predictions in the YOLO text format.  With the
+``--interactive`` flag the user can accept or skip detections after seeing
+a preview window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import cv2
+from ultralytics import YOLO
+
+logging.basicConfig(level=logging.INFO)
+
+Box = Tuple[int, float, float, float, float]
+
+
+def _to_yolo_format(result, width: int, height: int) -> List[Box]:
+    boxes: List[Box] = []
+    if not result.boxes:
+        return boxes
+    xyxy = result.boxes.xyxy.cpu().numpy()
+    cls = result.boxes.cls.cpu().numpy().astype(int)
+    for (x1, y1, x2, y2), c in zip(xyxy, cls):
+        cx = ((x1 + x2) / 2) / width
+        cy = ((y1 + y2) / 2) / height
+        w = (x2 - x1) / width
+        h = (y2 - y1) / height
+        boxes.append((int(c), cx, cy, w, h))
+    return boxes
+
+
+def _iter_images(dir_path: Path) -> Iterable[Path]:
+    exts = {".jpg", ".jpeg", ".png"}
+    for p in sorted(dir_path.iterdir()):
+        if p.suffix.lower() in exts:
+            yield p
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, help="ścieżka do wag YOLO")
+    parser.add_argument("--images", required=True, help="folder z obrazami")
+    parser.add_argument(
+        "--labels", required=True, help="folder zapisu etykiet (.txt)"
+    )
+    parser.add_argument(
+        "--confidence", type=float, default=0.25, help="próg ufności"
+    )
+    parser.add_argument(
+        "--interactive", action="store_true", help="podgląd i akceptacja"
+    )
+    args = parser.parse_args()
+
+    img_dir = Path(args.images)
+    lbl_dir = Path(args.labels)
+    lbl_dir.mkdir(parents=True, exist_ok=True)
+
+    if not img_dir.exists():
+        parser.error(f"Nie znaleziono katalogu {img_dir}")
+
+    try:
+        model = YOLO(args.model)
+    except Exception as exc:
+        parser.error(f"Nie można załadować modelu: {exc}")
+
+    images = list(_iter_images(img_dir))
+    if not images:
+        logging.warning("Katalog %s nie zawiera obrazów", img_dir)
+        return
+
+    logging.info("Przetwarzam %d obrazów…", len(images))
+    for img_path in images:
+        img = cv2.imread(str(img_path))
+        if img is None:
+            logging.error("Nie można odczytać %s, pomijam", img_path)
+            continue
+        result = model(img, conf=args.confidence, verbose=False)[0]
+        boxes = _to_yolo_format(result, img.shape[1], img.shape[0])
+
+        if args.interactive:
+            preview = result.plot()
+            cv2.imshow("label-assistant", preview)
+            key = cv2.waitKey(0)
+            cv2.destroyAllWindows()
+            if key not in (ord("y"), ord("Y"), 13, 32):
+                logging.info("Pominięto %s", img_path.name)
+                continue
+
+        label_path = lbl_dir / f"{img_path.stem}.txt"
+        with label_path.open("w", encoding="utf-8") as f:
+            for c, cx, cy, w, h in boxes:
+                f.write(f"{c} {cx:.6f} {cy:.6f} {w:.6f} {h:.6f}\n")
+        logging.info("Zapisano %s (%d boxów)", label_path, len(boxes))
+    logging.info("Gotowe.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/label_assistant.py` to generate YOLO-format labels with optional interactive review
- document dataset utilities and label assistant usage in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy'; AttributeError: module 'yaml' has no attribute 'safe_load')*

------
https://chatgpt.com/codex/tasks/task_e_68be6e5aaed48330a9f7dc0b79528ae4