### PR TITLE
Add packaging metadata and CLI validation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ METIIN-AI provides vision-based automation for the Metin2 game. It captures the 
    ```bash
    pip install -r requirements.txt
    ```
+   or using [Poetry](https://python-poetry.org/) for an isolated environment:
+   ```bash
+   poetry install
+   ```
 3. (Optional) Install GPU versions of ``torch``/``torchvision`` to speed up training and inference.
 
 ## Model Training

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,28 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "metiin-ai"
+version = "0.1.0"
+description = "Vision-based automation for the Metin2 game"
+requires-python = ">=3.10"
+dependencies = [
+    "numpy==2.3.2",
+    "opencv-python==4.12.0.88",
+    "pyautogui==0.9.54",
+    "PySide6==6.9.1",
+    "easyocr==1.7.2",
+    "ultralytics==8.3.186",
+    "torch==2.8.0",
+    "torchvision==0.23.0",
+    "Pillow==11.3.0",
+    "pynput==1.8.1",
+    "keyboard==0.13.5",
+    "pywin32>=306",
+    "pydantic>=2.11.7",
+]
+
 [tool.black]
 line-length = 88
 

--- a/tests/test_extract_frames_cli.py
+++ b/tests/test_extract_frames_cli.py
@@ -1,0 +1,22 @@
+import sys
+import types
+import pytest
+
+
+def test_extract_frames_invalid_step(monkeypatch):
+    dummy_cv2 = types.SimpleNamespace(
+        VideoCapture=lambda *a, **k: types.SimpleNamespace(
+            isOpened=lambda: True,
+            read=lambda: (False, None),
+            release=lambda: None,
+        ),
+        imwrite=lambda *a, **k: True,
+    )
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+    monkeypatch.setattr(sys, "argv", ["extract_frames", "--step", "0"])
+    import importlib
+    extract_frames = importlib.import_module("tools.extract_frames")
+    with pytest.raises(SystemExit) as exc:
+        extract_frames.main()
+    assert exc.value.code == 2
+


### PR DESCRIPTION
## Summary
- add PEP 621 project metadata and declare runtime dependencies
- document Poetry-based installation
- test frame extractor CLI argument validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be6f8ab38083308d2088f18ca29746