### PR TITLE
Add bilingual CLI help and messages

### DIFF
--- a/tools/capture_template.py
+++ b/tools/capture_template.py
@@ -14,8 +14,8 @@ The ``--roi`` argument specifies the region of interest in pixels relative to
 the Metin2 window, while ``--name`` determines the output filename.
 """
 
-import logging
 import argparse
+import logging
 from pathlib import Path
 
 import cv2
@@ -34,9 +34,13 @@ def main() -> None:
         type=int,
         metavar=("X", "Y", "W", "H"),
         default=[1000, 80, 90, 30],
-        help="współrzędne regionu okna Metin2",
+        help="coordinates of the Metin2 window region (współrzędne regionu okna Metin2)",
     )
-    parser.add_argument("--name", default="wczytaj", help="nazwa pliku wyjściowego")
+    parser.add_argument(
+        "--name",
+        default="wczytaj",
+        help="output file name (nazwa pliku wyjściowego)",
+    )
     args = parser.parse_args()
 
     out = Path("assets/templates")
@@ -45,15 +49,18 @@ def main() -> None:
     try:
         with WindowCapture("Metin2") as wc:  # fragment tytułu
             if not wc.locate(timeout=5):
-                raise RuntimeError("Nie znaleziono okna")
+                raise RuntimeError("Window not found (Nie znaleziono okna)")
             frame = np.array(wc.grab())[:, :, :3]
 
         x, y, w, h = args.roi
         out_path = out / f"{args.name}.png"
         cv2.imwrite(str(out_path), frame[y : y + h, x : x + w])
-        logging.info("Zapisano szablon: %s", out_path)
+        logging.info("Saved template: %s (Zapisano szablon)", out_path)
     except Exception as exc:
-        logging.error("Błąd podczas przechwytywania szablonu: %s", exc)
+        logging.error(
+            "Template capture failed: %s (Błąd podczas przechwytywania szablonu)",
+            exc,
+        )
 
 
 if __name__ == "__main__":

--- a/tools/extract_frames.py
+++ b/tools/extract_frames.py
@@ -21,16 +21,20 @@ logging.basicConfig(level=logging.INFO)
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--rec-dir", default="data/recordings", help="folder z nagraniami"
+        "--rec-dir",
+        default="data/recordings",
+        help="recordings folder (folder z nagraniami)",
     )
     parser.add_argument(
-        "--out-dir", default="datasets/mt2/images/train", help="folder zapisu klatek"
+        "--out-dir",
+        default="datasets/mt2/images/train",
+        help="output frames folder (folder zapisu klatek)",
     )
     parser.add_argument(
         "--step",
         type=int,
         default=15,
-        help="co ile klatek zapisać (przy 15 FPS → 1 kl/s)",
+        help="save every Nth frame (co ile klatek zapisać; przy 15 FPS → 1 kl/s)",
     )
     args = parser.parse_args()
 
@@ -42,19 +46,31 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if not rec_dir.exists():
-        parser.error(f"Nie znaleziono katalogu {rec_dir}")
+        parser.error(
+            f"Directory not found: {rec_dir} (Nie znaleziono katalogu {rec_dir})"
+        )
     videos = sorted(rec_dir.glob("*.mp4"))
     if not videos:
-        logging.warning("Katalog %s nie zawiera plików .mp4", rec_dir)
+        logging.warning(
+            "Directory %s contains no .mp4 files (Katalog %s nie zawiera plików .mp4)",
+            rec_dir,
+            rec_dir,
+        )
         return
 
-    logging.info("Znaleziono %d nagrań…", len(videos))
+    logging.info(
+        "Found %d recordings (Znaleziono %d nagrań…)", len(videos), len(videos)
+    )
     for vid in videos:
-        logging.info("Przetwarzam: %s", vid)
+        logging.info("Processing %s (Przetwarzam)", vid)
         try:
             cap = cv2.VideoCapture(str(vid))
             if not cap.isOpened():
-                logging.error("Nie można otworzyć pliku %s, pomijam", vid)
+                logging.error(
+                    "Cannot open file %s, skipping (Nie można otworzyć pliku %s, pomijam)",
+                    vid,
+                    vid,
+                )
                 continue
             i = 0
             saved = 0
@@ -68,10 +84,16 @@ def main() -> None:
                     saved += 1
                 i += 1
             cap.release()
-            logging.info(" zapisano %d klatek", saved)
+            logging.info("Saved %d frames (zapisano %d klatek)", saved, saved)
         except Exception as exc:
-            logging.error("Błąd podczas przetwarzania %s: %s", vid, exc)
-    logging.info("Gotowe.")
+            logging.error(
+                "Error processing %s: %s (Błąd podczas przetwarzania %s: %s)",
+                vid,
+                exc,
+                vid,
+                exc,
+            )
+    logging.info("Done. (Gotowe.)")
 
 
 if __name__ == "__main__":

--- a/tools/label_assistant.py
+++ b/tools/label_assistant.py
@@ -45,16 +45,31 @@ def _iter_images(dir_path: Path) -> Iterable[Path]:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", required=True, help="ścieżka do wag YOLO")
-    parser.add_argument("--images", required=True, help="folder z obrazami")
     parser.add_argument(
-        "--labels", required=True, help="folder zapisu etykiet (.txt)"
+        "--model",
+        required=True,
+        help="path to YOLO weights (ścieżka do wag YOLO)",
     )
     parser.add_argument(
-        "--confidence", type=float, default=0.25, help="próg ufności"
+        "--images",
+        required=True,
+        help="images folder (folder z obrazami)",
     )
     parser.add_argument(
-        "--interactive", action="store_true", help="podgląd i akceptacja"
+        "--labels",
+        required=True,
+        help="labels output folder (.txt) (folder zapisu etykiet (.txt))",
+    )
+    parser.add_argument(
+        "--confidence",
+        type=float,
+        default=0.25,
+        help="confidence threshold (próg ufności)",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="preview and accept (podgląd i akceptacja)",
     )
     args = parser.parse_args()
 
@@ -63,23 +78,37 @@ def main() -> None:
     lbl_dir.mkdir(parents=True, exist_ok=True)
 
     if not img_dir.exists():
-        parser.error(f"Nie znaleziono katalogu {img_dir}")
+        parser.error(
+            f"Directory not found: {img_dir} (Nie znaleziono katalogu {img_dir})"
+        )
 
     try:
         model = YOLO(args.model)
     except Exception as exc:
-        parser.error(f"Nie można załadować modelu: {exc}")
+        parser.error(f"Cannot load model: {exc} (Nie można załadować modelu: {exc})")
 
     images = list(_iter_images(img_dir))
     if not images:
-        logging.warning("Katalog %s nie zawiera obrazów", img_dir)
+        logging.warning(
+            "Directory %s contains no images (Katalog %s nie zawiera obrazów)",
+            img_dir,
+            img_dir,
+        )
         return
 
-    logging.info("Przetwarzam %d obrazów…", len(images))
+    logging.info(
+        "Processing %d images… (Przetwarzam %d obrazów…)",
+        len(images),
+        len(images),
+    )
     for img_path in images:
         img = cv2.imread(str(img_path))
         if img is None:
-            logging.error("Nie można odczytać %s, pomijam", img_path)
+            logging.error(
+                "Cannot read %s, skipping (Nie można odczytać %s, pomijam)",
+                img_path,
+                img_path,
+            )
             continue
         result = model(img, conf=args.confidence, verbose=False)[0]
         boxes = _to_yolo_format(result, img.shape[1], img.shape[0])
@@ -90,15 +119,21 @@ def main() -> None:
             key = cv2.waitKey(0)
             cv2.destroyAllWindows()
             if key not in (ord("y"), ord("Y"), 13, 32):
-                logging.info("Pominięto %s", img_path.name)
+                logging.info("Skipped %s (Pominięto)", img_path.name)
                 continue
 
         label_path = lbl_dir / f"{img_path.stem}.txt"
         with label_path.open("w", encoding="utf-8") as f:
             for c, cx, cy, w, h in boxes:
                 f.write(f"{c} {cx:.6f} {cy:.6f} {w:.6f} {h:.6f}\n")
-        logging.info("Zapisano %s (%d boxów)", label_path, len(boxes))
-    logging.info("Gotowe.")
+        logging.info(
+            "Saved %s (%d boxes) (Zapisano %s (%d boxów))",
+            label_path,
+            len(boxes),
+            label_path,
+            len(boxes),
+        )
+    logging.info("Done. (Gotowe.)")
 
 
 if __name__ == "__main__":

--- a/training/train_yolo.py
+++ b/training/train_yolo.py
@@ -9,16 +9,30 @@ from ultralytics import YOLO
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     ap = argparse.ArgumentParser()
-    ap.add_argument("--data", required=True, help="Ścieżka do data.yaml")
-    ap.add_argument("--model", default="yolov8n.pt", help="Waga startowa (lokalna)")
+    ap.add_argument(
+        "--data", required=True, help="path to data.yaml (Ścieżka do data.yaml)"
+    )
+    ap.add_argument(
+        "--model",
+        default="yolov8n.pt",
+        help="initial weights (Waga startowa, lokalna)",
+    )
     ap.add_argument("--epochs", type=int, default=50)
     ap.add_argument("--imgsz", type=int, default=640)
     ap.add_argument("--batch", type=int, default=16)
-    ap.add_argument("--device", default=None, help="cpu | 0 | 0,1 itp.")
+    ap.add_argument(
+        "--device",
+        default=None,
+        help="device: cpu | 0 | 0,1 etc. (cpu | 0 | 0,1 itp.)",
+    )
     args = ap.parse_args()
 
     try:
-        logging.info("Rozpoczynam trening YOLO na danych %s", args.data)
+        logging.info(
+            "Starting YOLO training on %s (Rozpoczynam trening YOLO na danych %s)",
+            args.data,
+            args.data,
+        )
         y = YOLO(args.model)
         y.train(
             data=args.data,
@@ -27,9 +41,15 @@ def main() -> None:
             batch=args.batch,
             device=args.device,
         )
-        logging.info("Trening YOLO zakończony pomyślnie")
+        logging.info(
+            "YOLO training completed successfully (Trening YOLO zakończony pomyślnie)"
+        )
     except Exception as exc:
-        logging.error("Błąd podczas treningu YOLO: %s", exc)
+        logging.error(
+            "YOLO training failed: %s (Błąd podczas treningu YOLO: %s)",
+            exc,
+            exc,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- provide English + Polish help texts for dataset tools and training script
- include bilingual log and error messages for better internationalization

## Testing
- `isort tools/capture_template.py tools/extract_frames.py tools/label_assistant.py training/train_yolo.py`
- `black tools/capture_template.py tools/extract_frames.py tools/label_assistant.py training/train_yolo.py`
- `flake8 tools/capture_template.py tools/extract_frames.py tools/label_assistant.py training/train_yolo.py` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68be7bc241648330bf3dfe65285c3f84