### PR TITLE
Expand tests for configuration loading and tool error cases

### DIFF
--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import types
+
+import pytest
+
+# Ensure repository root is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import agent
+
+
+def test_load_config_missing_file(tmp_path):
+    path = tmp_path / "missing.yaml"
+    cfg = agent.load_config(path)
+    assert isinstance(cfg, agent.AgentConfig)
+
+
+def test_load_config_reads_yaml(tmp_path, monkeypatch):
+    """load_config should parse data from YAML files."""
+
+    cfg_dict = {"controls": {"mouse_pause": 0.1}}
+    monkeypatch.setattr(agent, "yaml", types.SimpleNamespace(safe_load=lambda f: cfg_dict))
+    path = tmp_path / "cfg.yaml"
+    path.write_text("dummy")
+    cfg = agent.load_config(path)
+    assert cfg.controls.mouse_pause == 0.1

--- a/tests/test_extract_frames_cli.py
+++ b/tests/test_extract_frames_cli.py
@@ -20,3 +20,22 @@ def test_extract_frames_invalid_step(monkeypatch):
         extract_frames.main()
     assert exc.value.code == 2
 
+
+def test_extract_frames_missing_rec_dir(monkeypatch, tmp_path):
+    dummy_cv2 = types.SimpleNamespace(
+        VideoCapture=lambda *a, **k: types.SimpleNamespace(
+            isOpened=lambda: True,
+            read=lambda: (False, None),
+            release=lambda: None,
+        ),
+        imwrite=lambda *a, **k: True,
+    )
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+    missing = tmp_path / "nope"
+    monkeypatch.setattr(sys, "argv", ["extract_frames", "--rec-dir", str(missing)])
+    import importlib
+    sys.modules.pop("tools.extract_frames", None)
+    extract_frames = importlib.import_module("tools.extract_frames")
+    with pytest.raises(SystemExit) as exc:
+        extract_frames.main()
+    assert exc.value.code == 2

--- a/tests/test_window_capture.py
+++ b/tests/test_window_capture.py
@@ -55,3 +55,11 @@ def test_context_manager_closes(monkeypatch, platform):
     with wc.WindowCapture("foo") as cap:
         assert isinstance(cap.sct, DummySct)
     assert cap.sct.closed
+
+
+def test_locate_returns_false_when_window_missing(monkeypatch):
+    """WindowCapture.locate should return ``False`` if no window is found."""
+
+    wc = _import_wc(monkeypatch, "linux")
+    cap = wc.WindowCapture("does-not-exist", poll_sec=0)
+    assert cap.locate(timeout=0.01) is False


### PR DESCRIPTION
## Summary
- test configuration loader for missing file and YAML parsing
- cover WindowCapture `locate` when no game window is present
- ensure extract_frames CLI errors on absent recordings directory

## Testing
- `pytest tests/test_agent_config.py tests/test_window_capture.py tests/test_extract_frames_cli.py`
- `flake8 tests/test_agent_config.py tests/test_window_capture.py tests/test_extract_frames_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68be7bc8b78c83309adebfe02b9e6344