### PR TITLE
Refactor CycleFarm to asyncio

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import asyncio
 import time
 from typing import Callable, Optional, Tuple
 
@@ -233,6 +234,44 @@ class ChannelSwitcher:
                 if time.time() >= t_end:
                     break
                 time.sleep(0.1)
+            if current == start_ch:
+                rounds += 1
+        return False
+
+    async def cycle_until_target_seen_async(
+        self,
+        check_fn: Callable[[], bool],
+        *,
+        settle: float = 5.0,
+        timeout_per_ch: float = 5.0,
+        max_rounds: int = 1,
+    ) -> bool:
+        """Asynchronous variant of :meth:`cycle_until_target_seen`.
+
+        Uses ``asyncio.sleep`` for cooperative waiting so the event loop
+        can schedule other tasks (e.g. detector inference) while cycling
+        through channels.
+        """
+
+        current = self.current_channel_guess() or 1
+        start_ch = current
+        rounds = 0
+
+        if check_fn():
+            return True
+
+        while rounds < max_rounds:
+            current = self.next(current)
+            # ``switch`` is a blocking call; run it in a thread to avoid
+            # stalling the event loop.
+            await asyncio.to_thread(self.switch, current, post_wait=settle)
+            t_end = time.time() + timeout_per_ch
+            while True:
+                if check_fn():
+                    return True
+                if time.time() >= t_end:
+                    break
+                await asyncio.sleep(0.1)
             if current == start_ch:
                 rounds += 1
         return False

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -114,7 +115,7 @@ class CycleFarm:
         return bool(dets)
 
     # ---- logika pojedynczego slotu ----
-    def _process_slot(self, ch, slot, page_label, per_spot_sec, clear_sec):
+    async def _process_slot(self, ch, slot, page_label, per_spot_sec, clear_sec):
         """Handle teleportation and hunting on a single slot.
 
         PL: Obsłuż teleportację i polowanie na pojedynczym slocie.
@@ -130,9 +131,9 @@ class CycleFarm:
         logger.info("Teleportuję na slot %s (ch%s)", slot, ch)
         try:
             if hasattr(self.tp, "teleport_slot"):
-                self.tp.teleport_slot(slot, page_label)
+                await asyncio.to_thread(self.tp.teleport_slot, slot, page_label)
             else:
-                self.tp.teleport(slot, page_label)
+                await asyncio.to_thread(self.tp.teleport, slot, page_label)
         except Exception:
             logger.warning(
                 "Teleportacja na slot %s kanału %s nie powiodła się", slot, ch
@@ -142,7 +143,7 @@ class CycleFarm:
 
         if self.scanner and not self._any_target_seen():
             logger.debug("Brak celu po teleportacji – skanuję otoczenie")
-            self.scanner.scan()
+            await self.scanner.scan_async()
 
         if not self._any_target_seen() or self._stop:
             logger.info("Brak celu na slocie %s kanału %s", slot, ch)
@@ -153,14 +154,14 @@ class CycleFarm:
         t_end = time.time() + float(per_spot_sec)
         last_seen = time.time()
         while time.time() < t_end and not self._stop:
-            self.agent.step()
+            await asyncio.to_thread(self.agent.step)
             if self._any_target_seen():
                 last_seen = time.time()
             elif time.time() - last_seen > float(clear_sec):
                 if self.scanner:
-                    self.scanner.scan()
+                    await self.scanner.scan_async()
                 if not self._any_target_seen():
-                    self.ch.cycle_until_target_seen(
+                    await self.ch.cycle_until_target_seen_async(
                         check_fn=self._any_target_seen,
                         settle=self.ch_settle,
                         timeout_per_ch=self.ch_check,
@@ -170,11 +171,12 @@ class CycleFarm:
                     logger.debug("Pole czyste – przechodzę dalej")
                     break
                 last_seen = time.time()
+            await asyncio.sleep(0)
 
         self.cooldown[key] = time.time()
 
     # ---- główna pętla cyklu ----
-    def run(
+    async def run(
         self,
         page_label,
         ch_from,
@@ -235,13 +237,13 @@ class CycleFarm:
             if ch != current_ch:
                 logger.info("Przechodzę na kanał %s", ch)
                 try:
-                    self.ch.switch(ch, post_wait=self.ch_settle)
+                    await asyncio.to_thread(self.ch.switch, ch, post_wait=self.ch_settle)
                 except Exception:
                     logger.warning("Nie udało się zmienić kanału na %s", ch)
                 current_ch = ch
             if self._stop:
                 break
-            self._process_slot(ch, slot, page_label, per_spot_sec, clear_sec)
+            await self._process_slot(ch, slot, page_label, per_spot_sec, clear_sec)
 
         self.win.close()
         return

--- a/agent/scanner.py
+++ b/agent/scanner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
 from typing import Callable, Optional
@@ -81,6 +82,17 @@ class AreaScanner:
         self._stop.clear()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
+
+    async def scan_async(
+        self, progress_cb: Optional[Callable[[float], None]] = None
+    ) -> None:
+        """Asynchronous scan using ``asyncio`` for cooperative waits."""
+
+        if self.is_scanning():
+            return
+        self.scan(progress_cb)
+        while self.is_scanning():
+            await asyncio.sleep(self.pause)
 
     def cancel(self) -> None:
         """Cancel the running scan if any."""

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import time
+import asyncio
 
 import cv2
 import numpy as np
@@ -247,14 +248,16 @@ class CycleThread(QtCore.QThread):
         try:
             cf = CycleFarm(cfg)
             self.cycle_agent = cf
-            cf.run(
-                page_label=self.page,
-                ch_from=cycle_cfg.get("ch_from", 1),
-                ch_to=cycle_cfg.get("ch_to", 8),
-                slots=cycle_cfg.get("slots", list(range(1, 9))),
-                per_spot_sec=cycle_cfg.get("per_spot_sec", 90),
-                clear_sec=cycle_cfg.get("clear_sec", 6),
-                sequence=cycle_cfg.get("sequence"),
+            asyncio.run(
+                cf.run(
+                    page_label=self.page,
+                    ch_from=cycle_cfg.get("ch_from", 1),
+                    ch_to=cycle_cfg.get("ch_to", 8),
+                    slots=cycle_cfg.get("slots", list(range(1, 9))),
+                    per_spot_sec=cycle_cfg.get("per_spot_sec", 90),
+                    clear_sec=cycle_cfg.get("clear_sec", 6),
+                    sequence=cycle_cfg.get("sequence"),
+                )
             )
             self.status.emit(
                 QtCore.QCoreApplication.translate("MainWindow", "Cykl 8×8 zakończony.")

--- a/tests/test_cycle_sequence.py
+++ b/tests/test_cycle_sequence.py
@@ -1,3 +1,4 @@
+import asyncio
 import numpy as np
 
 
@@ -101,14 +102,16 @@ def test_cycle_sequence(monkeypatch):
         {"ch": 2, "slot": 4},
         {"ch": 1, "slot": 2},
     ]
-    cf.run(
-        page_label="P",
-        ch_from=1,
-        ch_to=2,
-        slots=[1, 2],
-        per_spot_sec=0,
-        clear_sec=0,
-        sequence=seq,
+    asyncio.run(
+        cf.run(
+            page_label="P",
+            ch_from=1,
+            ch_to=2,
+            slots=[1, 2],
+            per_spot_sec=0,
+            clear_sec=0,
+            sequence=seq,
+        )
     )
 
     switches = [c[1] for c in calls if c[0] == "ch"]


### PR DESCRIPTION
## Summary
- refactor CycleFarm's main loop to async and offload blocking steps with `asyncio.to_thread`
- add `cycle_until_target_seen_async` and `scan_async` helpers for non-blocking channel switching and area scans
- update GUI thread and unit test to run CycleFarm through `asyncio.run`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be7bd88524833087db296bc3e88d0b