### PR TITLE
Add optional TensorBoard support for RL training

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Rewards combine monster defeats, HP loss and a small time penalty, e.g.:
 -0.01 every step
 ```
 
+Install [TensorBoard](https://www.tensorflow.org/tensorboard) to monitor training; it is optional but recommended.
+
 Train an agent with [stable-baselines3](https://stable-baselines3.readthedocs.io/):
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pydantic==1.10.15
 pyyaml==6.0.2
 gymnasium==1.2.0
 stable-baselines3==2.7.0
+tensorboard>=2.0

--- a/training/train_rl_agent.py
+++ b/training/train_rl_agent.py
@@ -78,12 +78,19 @@ def main() -> None:
     if algo_cls is None:
         raise RuntimeError("stable_baselines3 is required for this script")
 
+    try:  # pragma: no cover - optional dependency for tests
+        import tensorboard  # type: ignore  # noqa: F401
+        tb_available = True
+    except Exception:  # pragma: no cover - allow running without tensorboard
+        logging.warning('TensorBoard is not installed; proceeding without logging.')
+        tb_available = False
+
     run_dir = Path(args.tensorboard_log) / f"{args.algo}_{datetime.now():%Y%m%d_%H%M%S}"
     run_dir.mkdir(parents=True, exist_ok=True)
 
     env = Metin2Env(frame_shape=(*args.frame_shape, 3))
 
-    kwargs = dict(learning_rate=args.learning_rate, tensorboard_log=str(run_dir))
+    kwargs = dict(learning_rate=args.learning_rate, tensorboard_log=str(run_dir) if tb_available else None)
     if args.algo == "dqn":
         kwargs.update(
             buffer_size=args.buffer_size,


### PR DESCRIPTION
## Summary
- add tensorboard optional dependency and import check for RL training
- document TensorBoard as optional dependency and add to requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec7c2b60c8330b4a521f67b6c5382