### PR TITLE
Log detector inference failures

### DIFF
--- a/agent_rl/metin2_env.py
+++ b/agent_rl/metin2_env.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import warnings
 
 import gymnasium as gym
@@ -84,7 +85,8 @@ class Metin2Env(gym.Env):
         bgr = frame[..., :3][:, :, ::-1]
         try:
             return self.detector.infer(bgr)
-        except Exception:
+        except Exception as exc:
+            logging.exception("Detector inference failed", exc_info=exc)
             return []
 
     def _read_hp(self, frame: np.ndarray) -> float:

--- a/tests/test_metin2_env.py
+++ b/tests/test_metin2_env.py
@@ -1,0 +1,29 @@
+import logging
+import os
+import sys
+import types
+import numpy as np
+
+# Ensure repository root is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub out optional dependencies used during import
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: types.SimpleNamespace(close=lambda: None)))
+sys.modules.setdefault("pygetwindow", types.SimpleNamespace(getAllWindows=lambda: []))
+
+from agent_rl.metin2_env import Metin2Env
+
+
+def test_detect_monsters_logs_exception(caplog):
+    env = Metin2Env(dry=True)
+
+    class Boom:
+        def infer(self, frame):  # pragma: no cover - raising intentionally
+            raise RuntimeError("boom")
+
+    env.detector = Boom()  # type: ignore
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+
+    caplog.set_level(logging.ERROR)
+    assert env._detect_monsters(frame) == []
+    assert "Detector inference failed" in caplog.text


### PR DESCRIPTION
## Summary
- log detector inference errors in Metin2Env
- add unit test verifying logging on detector failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec9cdeff48330a204460a4e988a89