### PR TITLE
Ensure environment closes on training errors

### DIFF
--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+import pytest
+
+# Ensure repository root is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub out optional dependencies used during import
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: types.SimpleNamespace(close=lambda: None)))
+sys.modules.setdefault("pygetwindow", types.SimpleNamespace(getAllWindows=lambda: []))
+
+from training import train_rl_agent
+
+
+def test_env_closed_on_training_exception(monkeypatch, tmp_path):
+    env_holder = {}
+
+    class DummyEnv:
+        def __init__(self, frame_shape):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    def fake_env(frame_shape):
+        env = DummyEnv(frame_shape)
+        env_holder["env"] = env
+        return env
+
+    class DummyModel:
+        def __init__(self, policy, env, **kwargs):
+            self.env = env
+
+        def learn(self, total_timesteps):  # pragma: no cover - raising intentionally
+            raise RuntimeError("boom")
+
+        def save(self, path):
+            pass
+
+    args = types.SimpleNamespace(
+        algo="dqn",
+        total_timesteps=1,
+        learning_rate=0.001,
+        buffer_size=1,
+        frame_shape=(1, 1),
+        batch_size=1,
+        exploration_initial_eps=1.0,
+        exploration_final_eps=0.05,
+        exploration_fraction=0.1,
+        gamma=0.99,
+        target_update_interval=1,
+        tensorboard_log=str(tmp_path),
+        save_name="test_model",
+    )
+
+    monkeypatch.setattr(train_rl_agent, "parse_args", lambda: args)
+    monkeypatch.setattr(train_rl_agent, "Metin2Env", fake_env)
+    monkeypatch.setitem(train_rl_agent.ALGORITHMS, "dqn", DummyModel)
+
+    with pytest.raises(RuntimeError):
+        train_rl_agent.main()
+
+    assert env_holder["env"].closed is True

--- a/training/train_rl_agent.py
+++ b/training/train_rl_agent.py
@@ -111,11 +111,14 @@ def main() -> None:
 
     model = algo_cls("CnnPolicy", env, **kwargs)
     logging.info("Starting training for %s steps", args.total_timesteps)
-    model.learn(total_timesteps=args.total_timesteps)
-    model_path = run_dir / args.save_name
-    model.save(str(model_path))
-    env.close()
-    logging.info("Model saved to %s", model_path)
+    try:
+        model.learn(total_timesteps=args.total_timesteps)
+        model_path = run_dir / args.save_name
+        model.save(str(model_path))
+        logging.info("Model saved to %s", model_path)
+    finally:
+        # Guarantee cleanup even if training fails
+        env.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Ensure RL training environment is always closed by wrapping `model.learn` in `try`/`finally`
- Add regression test verifying `env.close()` runs when training raises an exception

## Testing
- `pytest tests/test_train_rl_agent.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68becb78ddf08330b3b537b11cd323aa