### PR TITLE
Fix TensorBoard optional logging detection

### DIFF
--- a/tests/test_train_rl_agent.py
+++ b/tests/test_train_rl_agent.py
@@ -62,3 +62,54 @@ def test_env_closed_on_training_exception(monkeypatch, tmp_path):
         train_rl_agent.main()
 
     assert env_holder["env"].closed is True
+
+
+def test_tensorboard_skipped_when_unavailable(monkeypatch, tmp_path):
+    captured = {}
+
+    class DummyEnv:
+        def __init__(self, frame_shape):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_env(frame_shape):
+        return DummyEnv(frame_shape)
+
+    class DummyModel:
+        def __init__(self, policy, env, **kwargs):
+            captured.update(kwargs)
+
+        def learn(self, total_timesteps):
+            pass
+
+        def save(self, path):
+            pass
+
+    args = types.SimpleNamespace(
+        algo="dqn",
+        total_timesteps=1,
+        learning_rate=0.001,
+        buffer_size=1,
+        frame_shape=(1, 1),
+        batch_size=1,
+        exploration_initial_eps=1.0,
+        exploration_final_eps=0.05,
+        exploration_fraction=0.1,
+        gamma=0.99,
+        target_update_interval=1,
+        tensorboard_log=str(tmp_path),
+        save_name="test_model",
+    )
+
+    monkeypatch.setattr(train_rl_agent, "parse_args", lambda: args)
+    monkeypatch.setattr(train_rl_agent, "Metin2Env", fake_env)
+    monkeypatch.setitem(train_rl_agent.ALGORITHMS, "dqn", DummyModel)
+
+    # Ensure importing torch.utils.tensorboard fails
+    monkeypatch.setitem(sys.modules, "torch", types.SimpleNamespace())
+
+    train_rl_agent.main()
+
+    assert captured["tensorboard_log"] is None

--- a/training/train_rl_agent.py
+++ b/training/train_rl_agent.py
@@ -86,10 +86,10 @@ def main() -> None:
         raise RuntimeError("stable_baselines3 is required for this script")
 
     try:  # pragma: no cover - optional dependency for tests
-        import tensorboard  # type: ignore  # noqa: F401
+        from torch.utils.tensorboard import SummaryWriter  # type: ignore  # noqa: F401
         tb_available = True
     except Exception:  # pragma: no cover - allow running without tensorboard
-        logging.warning('TensorBoard is not installed; proceeding without logging.')
+        logging.warning("TensorBoard is not installed; proceeding without logging.")
         tb_available = False
 
     run_dir = Path(args.tensorboard_log) / f"{args.algo}_{datetime.now():%Y%m%d_%H%M%S}"


### PR DESCRIPTION
## Summary
- ensure RL training checks for `torch.utils.tensorboard` before enabling logging
- add regression test for tensorboard absence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bed2fc332c8330a6aaa80be77b662c