### PR TITLE
Launch TensorBoard during RL training

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -380,6 +380,7 @@ class RLTrainThread(QtCore.QThread):
 
     def run(self) -> None:  # pragma: no cover - GUI thread
         env = None
+        tb_proc = None
         try:
             self.status.emit(
                 QtCore.QCoreApplication.translate(
@@ -388,6 +389,9 @@ class RLTrainThread(QtCore.QThread):
             )
             from datetime import datetime
             from pathlib import Path
+            import subprocess
+            import shutil
+            import webbrowser
 
             from agent_rl import Metin2Env
             from stable_baselines3 import A2C, DQN, PPO
@@ -405,6 +409,13 @@ class RLTrainThread(QtCore.QThread):
             run_dir = Path("runs/rl") / f"{self.algo}_{datetime.now():%Y%m%d_%H%M%S}"
             run_dir.mkdir(parents=True, exist_ok=True)
 
+            if shutil.which("tensorboard"):
+                tb_proc = subprocess.Popen(["tensorboard", "--logdir", str(run_dir)])
+                try:
+                    webbrowser.open("http://localhost:6006")
+                except Exception:
+                    pass
+
             env = Metin2Env()
             model = algo_cls("CnnPolicy", env, tensorboard_log=str(run_dir))
             model.learn(total_timesteps=self.timesteps)
@@ -421,6 +432,11 @@ class RLTrainThread(QtCore.QThread):
                 ).format(exc=exc)
             )
         finally:
+            if tb_proc is not None:
+                try:
+                    tb_proc.terminate()
+                except Exception:
+                    pass
             if env is not None:
                 try:
                     env.close()

--- a/training/train_rl_agent.py
+++ b/training/train_rl_agent.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 
 import psutil
+import shutil
 
 from agent_rl import Metin2Env
 
@@ -86,8 +87,11 @@ def main() -> None:
         raise RuntimeError("stable_baselines3 is required for this script")
 
     try:  # pragma: no cover - optional dependency for tests
+        import torch  # type: ignore
+        if not hasattr(torch, "utils"):
+            raise ImportError
         from torch.utils.tensorboard import SummaryWriter  # type: ignore  # noqa: F401
-        tb_available = True
+        tb_available = shutil.which("tensorboard") is not None
     except Exception:  # pragma: no cover - allow running without tensorboard
         logging.warning("TensorBoard is not installed; proceeding without logging.")
         tb_available = False


### PR DESCRIPTION
## Summary
- start TensorBoard when RL training begins and open the dashboard in a browser
- ensure the TensorBoard process is terminated once training ends
- detect TensorBoard availability in CLI training script before enabling logging

## Testing
- `flake8 gui/main_window.py training/train_rl_agent.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfc0c67a088330ae8cf59864e5fb4f