### PR TITLE
refactor detection result to dataclass

### DIFF
--- a/agent/detector.py
+++ b/agent/detector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Dict, List
+from dataclasses import dataclass
 
 import cv2
 import numpy as np
@@ -11,6 +11,13 @@ from ultralytics import YOLO
 # particularly Windows, this can lead to high CPU usage or instability.
 # The thread count can now be controlled via ``ObjectDetector``.  By
 # default we leave OpenCV's configuration untouched.
+
+
+@dataclass
+class Detection:
+    name: str
+    bbox: list[float]
+    conf: float
 
 
 class ObjectDetector:
@@ -52,13 +59,13 @@ class ObjectDetector:
         # limit detekcji do ``max_fps`` razy na sekundę
         self.max_fps = max_fps
         self._last_infer_time = 0.0
-        self._last_result: List[Dict] = []
+        self._last_result: list[Detection] = []
         # dynamiczne skalowanie rozdzielczości
         self.dynamic_resize = dynamic_resize
         self.min_scale = min_scale
         self.scale = 1.0
 
-    def infer(self, frame_bgr: np.ndarray) -> List[Dict]:
+    def infer(self, frame_bgr: np.ndarray) -> list[Detection]:
         now = time.time()
         if self.max_fps:
             min_interval = 1.0 / self.max_fps
@@ -83,7 +90,7 @@ class ObjectDetector:
         )[0]
         infer_time = time.time() - start
 
-        out: List[Dict] = []
+        out: list[Detection] = []
         names = res.names
         for box in res.boxes:
             cls_id = int(box.cls)
@@ -98,11 +105,11 @@ class ObjectDetector:
                 x2 /= self.scale
                 y2 /= self.scale
             out.append(
-                {
-                    "name": name,
-                    "bbox": [x1, y1, x2, y2],
-                    "conf": float(box.conf.cpu().numpy()),
-                }
+                Detection(
+                    name=name,
+                    bbox=[x1, y1, x2, y2],
+                    conf=float(box.conf.cpu().numpy()),
+                )
             )
 
         self._last_result = out

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -8,7 +8,7 @@ import numpy as np
 from . import AgentConfig, get_config
 from .avoid import CollisionAvoid
 from .channel import ChannelSwitcher
-from .detector import ObjectDetector
+from .detector import ObjectDetector, Detection
 from .interaction import click_bbox_center
 from .movement import MovementController
 from .scanner import AreaScanner
@@ -38,7 +38,7 @@ class HuntDestroy(AgentStrategy):
         self.scanner = None
         self.search = None
         self.movement = None
-        self._last_tgt = None
+        self._last_tgt: Detection | None = None
         self._prev_names: set[str] = set()
         self._grab_lock = threading.Lock()
         if cfg is not None or window_capture is not None:
@@ -108,7 +108,7 @@ class HuntDestroy(AgentStrategy):
         H, W = frame.shape[:2]
         dets = self.det.infer(frame)
         logger.debug("Wykryto %s obiektów", len(dets))
-        cur_names = {d["name"] for d in dets}
+        cur_names = {d.name for d in dets}
         disappeared = self._prev_names - cur_names
         for name in disappeared:
             logger.debug("Obiekt %s zniknął", name)
@@ -117,7 +117,7 @@ class HuntDestroy(AgentStrategy):
         steer = self.avoid.steer(frame)
         tgt = pick_target(dets, (W, H), priority_order=self.priority)
         if tgt is None and self._last_tgt is not None:
-            logger.debug("Cel %s zniknął", self._last_tgt.get("name", "?"))
+            logger.debug("Cel %s zniknął", self._last_tgt.name)
         if tgt is None:
             logger.debug("Brak celu w zasięgu")
             if self.scanner:
@@ -140,7 +140,7 @@ class HuntDestroy(AgentStrategy):
 
         bw = None
         if tgt:
-            x1, y1, x2, y2 = tgt["bbox"]
+            x1, y1, x2, y2 = tgt.bbox
             bw = (x2 - x1) / W
 
         if tgt and bw is not None and bw >= self.desired_w * 0.9:
@@ -149,7 +149,7 @@ class HuntDestroy(AgentStrategy):
             if hasattr(self.keys, "dry") and self.keys.dry:
                 return
             logger.debug("Atakuję cel")
-            click_bbox_center(tgt["bbox"], (left, top, w, h), win=self.win)
+            click_bbox_center(tgt.bbox, (left, top, w, h), win=self.win)
         else:
             self.movement.move(tgt, steer, (W, H))
         self._last_tgt = tgt

--- a/agent/movement.py
+++ b/agent/movement.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from .wasd import KeyHold
+from .detector import Detection
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +20,14 @@ class MovementController:
         self.enabled = enabled
 
     def move(
-        self, tgt: dict | None, steer: str | None, frame_size: tuple[int, int]
+        self, tgt: Detection | None, steer: str | None, frame_size: tuple[int, int]
     ):
         """Update pressed keys to move towards the target and avoid obstacles.
 
         Parameters
         ----------
-        tgt: dict or None
-            Target detection dictionary with ``bbox``.
+        tgt: Detection or None
+            Target detection with ``bbox``.
         steer: str or None
             Direction suggested by the obstacle avoidance system (``"left"`` or
             ``"right"``).
@@ -45,7 +46,7 @@ class MovementController:
         bw = None
         if not self.enabled:
             if tgt:
-                x1, _, x2, _ = tgt["bbox"]
+                x1, _, x2, _ = tgt.bbox
                 bw = (x2 - x1) / W
             self.keys.release_all()
             return bw
@@ -59,7 +60,7 @@ class MovementController:
 
         bw = None
         if tgt:
-            x1, y1, x2, y2 = tgt["bbox"]
+            x1, y1, x2, y2 = tgt.bbox
             cx = (x1 + x2) / 2 / W
             bw = (x2 - x1) / W
             if abs(cx - 0.5) > self.deadzone:

--- a/agent/targets.py
+++ b/agent/targets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+from .detector import Detection
 
 DEFAULT_PRIORITY = ["boss", "metin", "potwory"]
 
@@ -13,31 +13,31 @@ def _rank(name: str, priority_order: list[str]) -> int:
 
 
 def pick_target(
-    dets: List[Dict],
-    wh: Tuple[int, int],
+    dets: list[Detection],
+    wh: tuple[int, int],
     priority_order: list[str] | None = None,
     center_bias: float = 2.0,
     size_bias: float = 1.0,
     center_y: float = 0.55,
-):
+) -> Detection | None:
     if not dets:
         return None
     W, H = wh
     order = priority_order or DEFAULT_PRIORITY
 
-    def score(d):
-        x1, y1, x2, y2 = d["bbox"]
+    def score(d: Detection):
+        x1, y1, x2, y2 = d.bbox
         cx = (x1 + x2) / 2 / W
         cy = (y1 + y2) / 2 / H
         bw = (x2 - x1) / W
         bh = (y2 - y1) / H
-        pr = _rank(d.get("name", ""), order)
+        pr = _rank(d.name, order)
         dist = abs(cx - 0.5) + abs(cy - center_y)
         return (
             pr * 10
             - center_bias * dist
             + size_bias * (bw * bh)
-            + 0.2 * float(d.get("conf", 0))
+            + 0.2 * d.conf
         )
 
     dets = sorted(dets, key=score, reverse=True)

--- a/agent_rl/metin2_env.py
+++ b/agent_rl/metin2_env.py
@@ -12,9 +12,10 @@ from agent.wasd import KeyHold
 from recorder.window_capture import WindowCapture
 
 try:  # ``ObjectDetector`` uses ``ultralytics`` which might be unavailable in tests
-    from agent.detector import ObjectDetector
+    from agent.detector import ObjectDetector, Detection
 except Exception:  # pragma: no cover - fallback for minimal environments
     ObjectDetector = None  # type: ignore
+    Detection = dict  # type: ignore
 
 
 class Metin2Env(gym.Env):
@@ -53,7 +54,7 @@ class Metin2Env(gym.Env):
         )
         if detector_model and self.detector is None:
             warnings.warn("Detector initialization failed; proceeding without it")
-        self._last_dets: list[dict] = []
+        self._last_dets: list[Detection] = []
         self._last_hp = 1.0
         # Region of the HP bar within the frame. Defaults assume top-left bar
         self.hp_bar = hp_bar or (slice(0, 20), slice(0, 200))
@@ -73,7 +74,7 @@ class Metin2Env(gym.Env):
         return frame, info
 
     # --- helpers ---------------------------------------------------------
-    def _detect_monsters(self, frame: np.ndarray) -> list[dict]:
+    def _detect_monsters(self, frame: np.ndarray) -> list[Detection]:
         """Run the configured detector on the frame and return detections.
 
         Returns an empty list when no detector is available. The frame is

--- a/gui/preview.py
+++ b/gui/preview.py
@@ -61,16 +61,16 @@ class PreviewWorker(QtCore.QThread):
                         try:
                             dets = self._det.infer(frame)
                             for d in dets:
-                                x1, y1, x2, y2 = map(int, d["bbox"])
+                                x1, y1, x2, y2 = map(int, d.bbox)
                                 color = (0, 0, 255)
-                                if d["name"] == "boss":
+                                if d.name == "boss":
                                     color = (0, 215, 255)
-                                elif d["name"] == "potwory":
+                                elif d.name == "potwory":
                                     color = (255, 128, 0)
                                 cv2.rectangle(frame, (x1, y1), (x2, y2), color, 2)
                                 cv2.putText(
                                     frame,
-                                    f"{d['name']} {d['conf']:.2f}",
+                                    f"{d.name} {d.conf:.2f}",
                                     (x1, max(12, y1 - 6)),
                                     cv2.FONT_HERSHEY_SIMPLEX,
                                     0.5,

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -79,7 +79,9 @@ def test_infer_filters_classes():
         model.predict.return_value = [FakeResult()]
         det = detector.ObjectDetector("model.pt", classes=["boss"])
         out = det.infer(frame)
-    assert out == [{"name": "boss", "bbox": [50.0, 60.0, 70.0, 80.0], "conf": 0.8}]
+    assert out == [
+        detector.Detection(name="boss", bbox=[50.0, 60.0, 70.0, 80.0], conf=0.8)
+    ]
 
 
 def test_infer_rate_limited():

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -77,6 +77,7 @@ channel_mod.ChannelSwitcher = _DummyChannelSwitcher
 sys.modules["agent.channel"] = channel_mod
 
 import agent.hunt_destroy as hd
+from agent.detector import Detection
 
 
 class _StubKeyHold:
@@ -118,7 +119,7 @@ class _DummyDetector:
         else:
             bbox = (30, 40, 40, 60)
         self.calls += 1
-        return [{"name": "enemy", "bbox": bbox}]
+        return [Detection(name="enemy", bbox=list(bbox), conf=0.0)]
 
 
 class _DummyAvoid:
@@ -258,7 +259,7 @@ def test_scan_interrupt_on_target(monkeypatch):
             self.calls += 1
             if self.calls < 3:
                 return []
-            return [{"name": "enemy", "bbox": (10, 10, 20, 20)}]
+            return [Detection(name="enemy", bbox=[10, 10, 20, 20], conf=0.0)]
 
     monkeypatch.setattr(hd, "ObjectDetector", _Detector)
 


### PR DESCRIPTION
## Summary
- add `Detection` dataclass to represent detector outputs
- return `list[Detection]` from `ObjectDetector.infer`
- update movement, targeting, strategies, GUI and tests to consume `Detection`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfc2cd1c508330b23941399abb3c31