### PR TITLE
Guard replay buffer against RAM overuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Train an agent with [stable-baselines3](https://stable-baselines3.readthedocs.io
 ```bash
 python training/train_rl_agent.py --algo dqn --total-timesteps 10000
 ```
+The replay buffer stores both current and next observations, so memory usage is
+approximately `buffer_size × H × W × 3 × dtype × 2`. With `uint8` 84×84 RGB
+frames this is ~42 KB per transition (~420 MB for the default `--buffer-size
+10000`). Reduce the buffer if RAM is limited, e.g.:
+
+```bash
+python training/train_rl_agent.py --algo dqn --total-timesteps 10000 --buffer-size 50000
+```
 
 TensorBoard logs and the final model are stored under `runs/rl/<algo_timestamp>/`.
 

--- a/training/train_rl_agent.py
+++ b/training/train_rl_agent.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 import psutil
+import numpy as np
 
 from agent_rl import Metin2Env
 
@@ -36,9 +37,10 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=10000,
         help=(
-            "Replay buffer capacity (transitions). Memory usage scales roughly as "
-            "buffer_size × bytes_per_transition; default 10000 with 84×84×3 "
-            "frames requires about 420 MB and will be reduced if RAM is insufficient."
+            "Replay buffer capacity (transitions). Memory usage scales as "
+            "buffer_size × frame_bytes × 2 where frame_bytes = H × W × 3 × dtype."
+            " 84×84×3 uint8 frames require ~42 KB per transition (~420 MB for 10k)."
+            " Reduce this with a smaller value if RAM is limited, e.g. --buffer-size 50000."
         ),
     )
     ap.add_argument(
@@ -66,7 +68,11 @@ def parse_args() -> argparse.Namespace:
     args = ap.parse_args()
     h, w = args.frame_shape
     frame_pixels = h * w * 3
-    bytes_per_transition = frame_pixels * 4 * 2  # obs and next_obs as float32
+    try:
+        obs_dtype = Metin2Env(frame_shape=(*args.frame_shape, 3)).observation_space.dtype
+    except Exception:
+        obs_dtype = np.uint8
+    bytes_per_transition = frame_pixels * np.dtype(obs_dtype).itemsize * 2
     required = args.buffer_size * bytes_per_transition
     available = psutil.virtual_memory().available
     if required > available:


### PR DESCRIPTION
## Summary
- compute replay buffer memory from Metin2Env's observation dtype
- shrink buffer size if required memory exceeds available RAM
- document memory formula and buffer-size option

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfd6e1bab08330a4ef9683cfa9d03f