### PR TITLE
Add reset actions and imitation learning utilities for Metin2 RL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ The script saves results under `runs/detect/train` by default. Adjust epochs, im
 The [`agent_rl`](agent_rl) package exposes Metin2 as a minimal Gym environment.
 `Metin2Env` wraps the game window and provides:
 
-- **Action space** – discrete actions mapped to key combinations (WASD, jump, etc.).
+- **Action space** – discrete actions mapped to key combinations. The default set now
+  includes camera rotation with ``q``/``e`` in addition to basic WASD movement.
 - **Observation space** – raw RGBA frames captured from the window.
 - **Info dict** – helper metrics such as current HP ratio and number of detected monsters.
+- **Dynamic reset** – optional keyboard sequences can be executed at reset to
+  teleport the player to a consistent starting location.
 
 Rewards combine monster defeats, HP loss and a small time penalty, e.g.:
 
@@ -72,6 +75,21 @@ python training/train_rl_agent.py --algo dqn --total-timesteps 10000 --buffer-si
 ```
 
 TensorBoard logs and the final model are stored under `runs/rl/<algo_timestamp>/`.
+The training script supports additional options:
+
+```bash
+python training/train_rl_agent.py --algo dqn --frame-stack 4 --dueling-dqn
+```
+
+`--frame-stack` wraps the environment with a frame stack for temporal context
+and `--dueling-dqn` enables the dueling architecture for SB3's DQN.
+
+For supervised pretraining from recorded sessions, a simple behaviour cloning
+utility is available:
+
+```bash
+python training/train_bc.py --dataset path/to/demos.npz --epochs 10
+```
 
 Each environment step yields `(observation, reward, done, info)` where:
 

--- a/agent_rl/metin2_env.py
+++ b/agent_rl/metin2_env.py
@@ -39,10 +39,12 @@ class Metin2Env(gym.Env):
         kill_reward: float = 1.0,
         damage_penalty: float = 1.0,
         time_penalty: float = 0.01,
+        reset_actions: list[list[str]] | None = None,
     ) -> None:
         super().__init__()
         self.title = title
-        self.key_map = key_map or [["w"], ["a"], ["s"], ["d"], ["space"], []]
+        # default action map now includes camera rotation keys ``q`` and ``e``
+        self.key_map = key_map or [["w"], ["a"], ["s"], ["d"], ["space"], [], ["q"], ["e"]]
         self.action_space = spaces.Discrete(len(self.key_map))
         self.frame_shape = frame_shape
         self.observation_space = spaces.Box(
@@ -62,6 +64,8 @@ class Metin2Env(gym.Env):
         self.kill_reward = kill_reward
         self.damage_penalty = damage_penalty
         self.time_penalty = time_penalty
+        # optional keyboard sequences executed on environment reset (e.g. teleport)
+        self.reset_actions = reset_actions or []
         # Region of the HP bar within the frame. Defaults assume top-left bar
         self.hp_bar = hp_bar or (slice(0, 20), slice(0, 200))
 
@@ -71,6 +75,14 @@ class Metin2Env(gym.Env):
             self.wincap.close()
         self.wincap = WindowCapture(self.title)
         self.wincap.locate()
+        # perform optional reset actions to place the player at a known start
+        for combo in self.reset_actions:
+            if not combo:
+                continue
+            if len(combo) == 1:
+                self.kb.tap(combo[0])
+            else:
+                self.kb.hotkey(combo)
         img = self.wincap.grab()
         frame = self._preprocess(
             np.frombuffer(img.rgb, dtype=np.uint8).reshape(img.height, img.width, 3)

--- a/tests/test_metin2_env.py
+++ b/tests/test_metin2_env.py
@@ -27,3 +27,31 @@ def test_detect_monsters_logs_exception(caplog):
     caplog.set_level(logging.ERROR)
     assert env._detect_monsters(frame) == []
     assert "Detector inference failed" in caplog.text
+
+
+def test_reset_actions(monkeypatch):
+    calls = []
+
+    class DummyWC:
+        def __init__(self, title):
+            pass
+
+        def locate(self):
+            pass
+
+        def grab(self):
+            return types.SimpleNamespace(width=1, height=1, rgb=b"\x00\x00\x00")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("agent_rl.metin2_env.WindowCapture", DummyWC)
+    env = Metin2Env(dry=True, reset_actions=[["x"], ["y", "z"]])
+
+    monkeypatch.setattr(env.kb, "tap", lambda k: calls.append(("tap", k)))
+    monkeypatch.setattr(env.kb, "hotkey", lambda keys: calls.append(("hotkey", tuple(keys))))
+
+    env.reset()
+
+    assert ("tap", "x") in calls
+    assert ("hotkey", ("y", "z")) in calls

--- a/training/train_bc.py
+++ b/training/train_bc.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Train a behavior cloning model")
+    ap.add_argument("--dataset", required=True, help="path to npz with 'obs' and 'actions'")
+    ap.add_argument("--epochs", type=int, default=5)
+    ap.add_argument("--batch-size", type=int, default=32)
+    ap.add_argument("--learning-rate", type=float, default=1e-3)
+    ap.add_argument("--save-path", default="bc_model.pt")
+    return ap.parse_args()
+
+
+def build_model(num_actions: int) -> nn.Module:
+    return nn.Sequential(
+        nn.Conv2d(3, 16, kernel_size=3, stride=2),
+        nn.ReLU(),
+        nn.Conv2d(16, 32, kernel_size=3, stride=2),
+        nn.ReLU(),
+        nn.Flatten(),
+        nn.Linear(32 * 20 * 20, 128),  # assumes 84x84 input
+        nn.ReLU(),
+        nn.Linear(128, num_actions),
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    data = np.load(args.dataset)
+    obs = torch.from_numpy(data["obs"]).float() / 255.0
+    obs = obs.permute(0, 3, 1, 2)  # NHWC -> NCHW
+    actions = torch.from_numpy(data["actions"]).long()
+    dataset = TensorDataset(obs, actions)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+
+    num_actions = int(actions.max().item() + 1)
+    model = build_model(num_actions)
+    opt = optim.Adam(model.parameters(), lr=args.learning_rate)
+    loss_fn = nn.CrossEntropyLoss()
+
+    model.train()
+    for _ in range(args.epochs):
+        for x, y in loader:
+            opt.zero_grad()
+            logits = model(x)
+            loss = loss_fn(logits, y)
+            loss.backward()
+            opt.step()
+
+    Path(args.save_path).parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), args.save_path)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/training/train_rl_agent.py
+++ b/training/train_rl_agent.py
@@ -14,10 +14,10 @@ from agent_rl import Metin2Env
 try:  # pragma: no cover - optional dependency for tests
     from stable_baselines3 import A2C, DQN, PPO
     from stable_baselines3.common.env_util import make_vec_env
-    from stable_baselines3.common.vec_env import VecTransposeImage
+    from stable_baselines3.common.vec_env import VecTransposeImage, VecFrameStack
     from stable_baselines3.common.callbacks import EvalCallback
 except Exception:  # pragma: no cover - allow importing without sb3 installed
-    A2C = DQN = PPO = make_vec_env = VecTransposeImage = EvalCallback = None  # type: ignore
+    A2C = DQN = PPO = make_vec_env = VecTransposeImage = VecFrameStack = EvalCallback = None  # type: ignore
 
 
 ALGORITHMS = {
@@ -65,6 +65,8 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--damage-penalty", type=float, default=1.0)
     ap.add_argument("--time-penalty", type=float, default=0.01)
     ap.add_argument("--num-envs", type=int, default=1, help="number of parallel environments")
+    ap.add_argument("--frame-stack", type=int, default=1, help="frames to stack")
+    ap.add_argument("--dueling-dqn", action="store_true", help="enable dueling architecture for DQN")
 
     args = ap.parse_args()
     h, w = args.frame_shape
@@ -140,6 +142,8 @@ def main() -> None:
     try:
         env = make_vec_env(_make_env, n_envs=args.num_envs)
         env = VecTransposeImage(env)
+        if VecFrameStack is not None and getattr(args, "frame_stack", 1) > 1:
+            env = VecFrameStack(env, n_stack=args.frame_stack)
     except Exception:  # pragma: no cover - fallback when vec env wrappers are unavailable
         env = _make_env()
 
@@ -162,6 +166,8 @@ def main() -> None:
             try:
                 eval_env = make_vec_env(_make_eval_env, n_envs=1)
                 eval_env = VecTransposeImage(eval_env)
+                if VecFrameStack is not None and getattr(args, "frame_stack", 1) > 1:
+                    eval_env = VecFrameStack(eval_env, n_stack=args.frame_stack)
             except Exception:  # pragma: no cover - fallback when vec env wrappers are unavailable
                 eval_env = _make_eval_env()
 
@@ -191,6 +197,8 @@ def main() -> None:
             gamma=args.gamma,
             target_update_interval=args.target_update_interval,
         )
+        if getattr(args, "dueling_dqn", False):
+            kwargs["policy_kwargs"] = {"dueling": True}
 
     model = algo_cls("CnnPolicy", env, **kwargs)
     logging.info("Starting training for %s steps", args.total_timesteps)


### PR DESCRIPTION
## Summary
- extend Metin2 gym environment with camera rotation actions and optional reset sequences
- add frame stacking and dueling DQN options to RL training script
- provide a simple behavior cloning training utility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfdbccb37c8330acd49653f59eee4b