### PR TITLE
Delay opening TensorBoard until it starts

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -412,6 +412,7 @@ class RLTrainThread(QtCore.QThread):
             if shutil.which("tensorboard"):
                 tb_proc = subprocess.Popen(["tensorboard", "--logdir", str(run_dir)])
                 try:
+                    time.sleep(5)  # wait for TensorBoard to initialize
                     webbrowser.open("http://localhost:6006")
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary
- wait briefly after launching TensorBoard before opening browser to ensure UI is ready

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfecf6eaf08330b8874b98006138cd