### PR TITLE
Ensure teleport panel region fits templates

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -138,10 +138,10 @@ class Teleporter:
 
         L, T, w, h = self.win.region
         roi = (
-            int(w * 0.05),
-            int(h * 0.82),
-            int(w * 0.9),
-            int(h * 0.16),
+            0,
+            int(h * 0.80),
+            w,
+            int(h * 0.20),
         )
         screen_roi = (L + roi[0], T + roi[1], roi[2], roi[3])
         page_refs = [
@@ -196,8 +196,27 @@ class Teleporter:
                     ref_name,
                 )
                 try:
+                    template_img = Image.open(template_path)
+                    tw, th = template_img.size
+                    sr_w, sr_h = screen_roi[2], screen_roi[3]
+                    if tw > sr_w or th > sr_h:
+                        scale = min(sr_w / tw, sr_h / th)
+                        if scale < 1:
+                            new_size = (
+                                max(1, int(tw * scale)),
+                                max(1, int(th * scale)),
+                            )
+                            template_img = template_img.resize(new_size, Image.LANCZOS)
+                            logger.debug(
+                                "Resized template %s from (%d, %d) to %s to fit region %s",
+                                ref_name,
+                                tw,
+                                th,
+                                new_size,
+                                screen_roi,
+                            )
                     found = pyautogui.locateOnScreen(
-                        str(template_path),
+                        template_img,
                         region=screen_roi,
                         confidence=self.page_thresh,
                     )

--- a/tests/test_teleport_open_panel.py
+++ b/tests/test_teleport_open_panel.py
@@ -34,10 +34,23 @@ sys.modules.setdefault("easyocr", types.SimpleNamespace(Reader=lambda *a, **k: N
 # Provide a minimal numpy stub for imports
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 
-# Stub PIL.Image used for saving screenshots
+# Stub PIL.Image used for image operations
+class _FakeImage:
+    def __init__(self, size):
+        self.size = size
+
+    def resize(self, size, resample=None):
+        return _FakeImage(size)
+
+
+def _fake_open(path):  # pylint: disable=unused-argument
+    return _FakeImage(_fake_open.size)
+
+
 PIL_stub = types.ModuleType("PIL")
-PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.Image = types.SimpleNamespace(open=_fake_open, LANCZOS=0)
 sys.modules.setdefault("PIL", PIL_stub)
+_fake_open.size = (10, 10)
 
 # Stub pyautogui to avoid real key presses
 pyautogui_stub = types.SimpleNamespace(
@@ -110,3 +123,39 @@ def test_open_panel_detects_non_first_page():
     assert teleporter.open_panel() is True
     assert hotkey_calls == [(["ctrl", "x"], 0.05)]
     assert call_order[:2] == ["strona_I", "strona_II"]
+
+
+def test_open_panel_scales_large_template():
+    teleporter = Teleporter.__new__(Teleporter)
+    teleporter.dry = False
+    teleporter.keys = types.SimpleNamespace(hotkey=lambda *a, **k: None)
+    teleporter.open_panel_delay = 0
+    teleporter.page_thresh = 0.5
+    teleporter.win = types.SimpleNamespace(
+        focus=lambda: None,
+        is_foreground=lambda: True,
+        region=(0, 0, 100, 100),
+    )
+    teleporter._frame = lambda: types.SimpleNamespace(shape=(1, 1, 3))
+
+    class TM:
+        dir = Path(".")
+
+        def find(self, frame, name, thresh, roi, multi_scale):  # noqa: ARG002
+            return None
+
+    teleporter.tm = TM()
+
+    # simulate template larger than search region
+    _fake_open.size = (120, 30)
+
+    calls: list[tuple[tuple[int, int], tuple[int, int, int, int]]] = []
+
+    def _locate(template, region=None, confidence=None):  # noqa: ARG001
+        calls.append((template.size, region))
+        return object()
+
+    pyautogui_stub.locateOnScreen = _locate
+
+    assert teleporter.open_panel() is True
+    assert calls == [((80, 20), (0, 80, 100, 20))]


### PR DESCRIPTION
## Summary
- widen teleport panel ROI to cover full panel
- resize oversized templates before `pyautogui.locateOnScreen`
- add test for large template handling

## Testing
- `pytest tests/test_teleport_open_panel.py tests/test_teleport_close_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68c014f9cabc83309eabde6fa5578bb1