### PR TITLE
Remove teleport panel detection

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -120,127 +120,37 @@ class Teleporter:
         pyautogui.click()
 
     def open_panel(self, max_attempts: int = 3) -> bool:
-        """Open teleport panel and verify it appears.
+        """Open teleport panel using ``Ctrl+X`` without any verification.
 
-        Sends the ``Ctrl+X`` hotkey, takes a screenshot and checks whether any
-        of the page templates (``strona_I.png`` .. ``strona_VIII.png``) is
-        visible.  For each template the check is performed first with
-        :class:`TemplateMatcher` and then, if needed, with
-        :func:`pyautogui.locateOnScreen`.  The function returns as soon as a
-        template matches.  When the panel is not detected the hotkey is retried
-        ``max_attempts`` times before raising :class:`RuntimeError`.
+        The previous implementation attempted to detect the panel on the
+        screen using template matching and ``pyautogui.locateOnScreen``.  This
+        detection step has been removed on request, so the function now merely
+        sends the hotkey and assumes the panel is open.  It returns ``True``
+        if the window was in the foreground when the hotkey was sent, otherwise
+        ``False``.
         """
 
         self.win.focus()
         if not self.win.is_foreground():
-            logger.debug("Window is not in foreground before opening teleport panel")
+            logger.debug(
+                "Window is not in foreground before opening teleport panel"
+            )
             return False
 
-        L, T, w, h = self.win.region
-        roi = (
-            0,
-            int(h * 0.80),
-            w,
-            int(h * 0.20),
-        )
-        screen_roi = (L + roi[0], T + roi[1], roi[2], roi[3])
-        page_refs = [
-            f"strona_{r}" for r in ["I", "II", "III", "IV", "V", "VI", "VII", "VIII"]
-        ]
-        logger.debug(
-            "open_panel setup: region=%s ROI=%s screen_roi=%s templates=%s thresh=%.3f",
-            self.win.region,
-            roi,
-            screen_roi,
-            page_refs,
-            self.page_thresh,
-        )
-
-        frame = None
         for attempt in range(max_attempts):
-            if not self.win.is_foreground():
-                logger.debug("Window not in foreground on attempt %d", attempt + 1)
-            logger.debug("Attempt %d to open teleport panel", attempt + 1)
+            logger.debug(
+                "Attempt %d to open teleport panel (no detection)", attempt + 1
+            )
             if not self.dry:
                 self.keys.hotkey(["ctrl", "x"], duration=0.05)
-            else:
-                return True
             time.sleep(self.open_panel_delay)
-
-            frame = self._frame()
-            logger.debug(
-                "Captured frame shape: %s", None if frame is None else frame.shape
-            )
             if not self.win.is_foreground():
                 logger.debug(
                     "Window lost foreground after keypress on attempt %d", attempt + 1
                 )
-
-            found = None
-            for ref_name in page_refs:
-                template_path = self.tm.dir / f"{ref_name}.png"
-                found = self.tm.find(
-                    frame,
-                    ref_name,
-                    thresh=self.page_thresh,
-                    roi=roi,
-                    multi_scale=True,
-                )
-                if found:
-                    logger.debug(
-                        "TemplateMatcher found %s on attempt %d", ref_name, attempt + 1
-                    )
-                    return True
-                logger.debug(
-                    "TemplateMatcher did not find %s; falling back to pyautogui.locateOnScreen",
-                    ref_name,
-                )
-                try:
-                    template_img = Image.open(template_path)
-                    tw, th = template_img.size
-                    sr_w, sr_h = screen_roi[2], screen_roi[3]
-                    if tw > sr_w or th > sr_h:
-                        scale = min(sr_w / tw, sr_h / th)
-                        if scale < 1:
-                            new_size = (
-                                max(1, int(tw * scale)),
-                                max(1, int(th * scale)),
-                            )
-                            template_img = template_img.resize(new_size, Image.LANCZOS)
-                            logger.debug(
-                                "Resized template %s from (%d, %d) to %s to fit region %s",
-                                ref_name,
-                                tw,
-                                th,
-                                new_size,
-                                screen_roi,
-                            )
-                    found = pyautogui.locateOnScreen(
-                        template_img,
-                        region=screen_roi,
-                        confidence=self.page_thresh,
-                    )
-                    logger.debug(
-                        "pyautogui.locateOnScreen result for %s: %s", ref_name, found
-                    )
-                except Exception:
-                    logger.debug(
-                        "pyautogui.locateOnScreen raised exception for %s", ref_name, exc_info=True
-                    )
-                    found = None
-                if found:
-                    logger.debug(
-                        "Teleport panel detected via pyautogui for %s on attempt %d",
-                        ref_name,
-                        attempt + 1,
-                    )
-                    return True
-            logger.debug("Teleport panel not detected on attempt %d", attempt + 1)
-
-        logger.warning("Teleport panel not detected after %d attempts", max_attempts)
-        if frame is not None:
-            self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
-        raise RuntimeError("Teleport panel not detected")
+                return False
+            return True
+        return True
 
     def close_panel(self) -> None:
         """Close the teleport panel if it is open."""
@@ -299,9 +209,7 @@ class Teleporter:
 
         logger.debug("Teleporting to slot %s on page '%s'", slot, page_label)
         # otwórz panel i przejdź do strony
-        try:
-            self.open_panel()
-        except RuntimeError:
+        if not self.open_panel():
             frame = self._frame()
             self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
             return TeleportResult.TEMPLATE_NOT_FOUND

--- a/tests/test_teleport_open_panel.py
+++ b/tests/test_teleport_open_panel.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import types
-from pathlib import Path
 
 # Ensure repository root on path and stub optional dependencies
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,43 +13,31 @@ sys.modules.setdefault("yaml", yaml_stub)
 # Minimal pydantic stub providing BaseModel and Field
 _pydantic = types.ModuleType("pydantic")
 
-class _BaseModel:
+
+class _BaseModel:  # pragma: no cover - simple stub
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-def _Field(default=None, default_factory=None, **kwargs):
+
+def _Field(default=None, default_factory=None, **kwargs):  # pragma: no cover
     if default_factory is not None:
         return default_factory()
     return default
+
 
 _pydantic.BaseModel = _BaseModel
 _pydantic.Field = _Field
 sys.modules.setdefault("pydantic", _pydantic)
 
-# Stub easyocr to avoid heavy import
+# Stub easyocr and numpy to avoid heavy imports
 sys.modules.setdefault("easyocr", types.SimpleNamespace(Reader=lambda *a, **k: None))
-
-# Provide a minimal numpy stub for imports
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 
-# Stub PIL.Image used for image operations
-class _FakeImage:
-    def __init__(self, size):
-        self.size = size
-
-    def resize(self, size, resample=None):
-        return _FakeImage(size)
-
-
-def _fake_open(path):  # pylint: disable=unused-argument
-    return _FakeImage(_fake_open.size)
-
-
+# Stub PIL.Image used for saving screenshots
 PIL_stub = types.ModuleType("PIL")
-PIL_stub.Image = types.SimpleNamespace(open=_fake_open, LANCZOS=0)
+PIL_stub.Image = types.SimpleNamespace()
 sys.modules.setdefault("PIL", PIL_stub)
-_fake_open.size = (10, 10)
 
 # Stub pyautogui to avoid real key presses
 pyautogui_stub = types.SimpleNamespace(
@@ -67,8 +54,10 @@ recorder_pkg = types.ModuleType("recorder")
 recorder_pkg.__path__ = []
 wc_mod = types.ModuleType("recorder.window_capture")
 
-class WindowCapture:
+
+class WindowCapture:  # pragma: no cover - minimal stub
     pass
+
 
 wc_mod.WindowCapture = WindowCapture
 recorder_pkg.window_capture = wc_mod
@@ -78,9 +67,11 @@ sys.modules.setdefault("recorder.window_capture", wc_mod)
 # Stub agent.template_matcher used during import
 tm_stub = types.ModuleType("agent.template_matcher")
 
-class _TM:
+
+class _TM:  # pragma: no cover - minimal stub
     def __init__(self, *a, **k):
         pass
+
 
 tm_stub.TemplateMatcher = _TM
 sys.modules.setdefault("agent.template_matcher", tm_stub)
@@ -89,73 +80,34 @@ sys.modules.pop("agent.teleport", None)
 from agent.teleport import Teleporter
 
 
-def test_open_panel_detects_non_first_page():
+def test_open_panel_sends_hotkey_and_returns_true():
     teleporter = Teleporter.__new__(Teleporter)
     teleporter.dry = False
-    hotkey_calls: list[tuple[list[str], float]] = []
+    calls: list[tuple[list[str], float]] = []
 
     def _hotkey(keys, duration=0.05):
-        hotkey_calls.append((keys, duration))
+        calls.append((keys, duration))
 
     teleporter.keys = types.SimpleNamespace(hotkey=_hotkey)
     teleporter.open_panel_delay = 0
-    teleporter.page_thresh = 0.5
     teleporter.win = types.SimpleNamespace(
         focus=lambda: None,
         is_foreground=lambda: True,
-        region=(0, 0, 100, 100),
     )
-    teleporter._frame = lambda: types.SimpleNamespace(shape=(1, 1, 3))
-
-    call_order = []
-
-    class TM:
-        dir = Path(".")
-
-        def find(self, frame, name, thresh, roi, multi_scale):
-            call_order.append(name)
-            if name == "strona_II":
-                return object()
-            return None
-
-    teleporter.tm = TM()
 
     assert teleporter.open_panel() is True
-    assert hotkey_calls == [(["ctrl", "x"], 0.05)]
-    assert call_order[:2] == ["strona_I", "strona_II"]
+    assert calls == [(["ctrl", "x"], 0.05)]
 
 
-def test_open_panel_scales_large_template():
+def test_open_panel_returns_false_when_not_foreground():
     teleporter = Teleporter.__new__(Teleporter)
     teleporter.dry = False
     teleporter.keys = types.SimpleNamespace(hotkey=lambda *a, **k: None)
     teleporter.open_panel_delay = 0
-    teleporter.page_thresh = 0.5
     teleporter.win = types.SimpleNamespace(
         focus=lambda: None,
-        is_foreground=lambda: True,
-        region=(0, 0, 100, 100),
+        is_foreground=lambda: False,
     )
-    teleporter._frame = lambda: types.SimpleNamespace(shape=(1, 1, 3))
 
-    class TM:
-        dir = Path(".")
+    assert teleporter.open_panel() is False
 
-        def find(self, frame, name, thresh, roi, multi_scale):  # noqa: ARG002
-            return None
-
-    teleporter.tm = TM()
-
-    # simulate template larger than search region
-    _fake_open.size = (120, 30)
-
-    calls: list[tuple[tuple[int, int], tuple[int, int, int, int]]] = []
-
-    def _locate(template, region=None, confidence=None):  # noqa: ARG001
-        calls.append((template.size, region))
-        return object()
-
-    pyautogui_stub.locateOnScreen = _locate
-
-    assert teleporter.open_panel() is True
-    assert calls == [((80, 20), (0, 80, 100, 20))]


### PR DESCRIPTION
## Summary
- Simplify teleport panel opening to just send Ctrl+X with no template checks
- Adjust teleport slot logic to handle boolean open_panel result
- Update teleport open panel tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c019a9ee2883309c78222c17712317