### PR TITLE
Remove teleport panel detection

### DIFF
--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-import logging
-import os
-import time
-from enum import Enum, auto
+"""Coordinate based teleporter."""
 
-import easyocr
-import numpy as np
+import logging
+import time
+from enum import Enum
+
 import pyautogui
-from PIL import Image
 
 from recorder.window_capture import WindowCapture
 
-from . import AgentConfig, get_config
-from .template_matcher import TemplateMatcher
+from . import AgentConfig, get_config, teleport_config as tc
 
 try:  # pragma: no cover - prefer pydirectinput if available
     from pydirectinput import KeyHold  # type: ignore
@@ -26,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 class TeleportResult(Enum):
+    """Possible outcomes of a teleport attempt."""
+
     OK = "ok"
     TEMPLATE_NOT_FOUND = "template_not_found"
     OCR_MISS = "ocr_miss"
@@ -33,31 +32,21 @@ class TeleportResult(Enum):
 
 
 class Teleporter:
-    """Teleport panel helper.
+    """Simple teleporter that clicks preconfigured coordinates.
 
-    - ``open_panel()``: Ctrl+X (with focus)
-    - ``go_page('Page I'..'Page VIII')``
-    - ``teleport(point, page)``
-    - ``teleport_slot(slot, page)``: scroll + retry, click "Load"
-    Requires templates: ``wczytaj.png``, ``strona_I.png``..``strona_VIII.png``
-
-    PL:
-    Panel teleportu:
-    - open_panel(): Ctrl+X (z focusem)
-    - go_page('Strona I'..'Strona VIII')
-    - teleport(point, page)
-    - teleport_slot(slot, page): scroll + retry, klik 'Wczytaj'
-    Wymaga szablonów: wczytaj.png, strona_I.png..strona_VIII.png
+    All template and OCR based detection has been removed.  Teleportation now
+    relies solely on sending the ``Ctrl+X`` hotkey to open the teleport panel
+    and clicking coordinates loaded from ``config/teleport.yaml``.
     """
 
     def __init__(
         self,
         win: WindowCapture,
-        templates_dir: str,
-        use_ocr: bool = True,
+        templates_dir: str | None = None,
+        use_ocr: bool = False,
         dry: bool = False,
         cfg: AgentConfig | dict | None = None,
-    ):
+    ) -> None:
         if cfg is None:
             cfg = CFG
         elif isinstance(cfg, dict):
@@ -65,50 +54,14 @@ class Teleporter:
         self.cfg = cfg
         pyautogui.PAUSE = self.cfg.controls.mouse_pause
         self.win = win
-        if not os.path.isdir(templates_dir):
-            raise FileNotFoundError(f"Brak katalogu z szablonami: {templates_dir}")
-        required = ["wczytaj.png"] + [
-            f"strona_{r}.png"
-            for r in ["I", "II", "III", "IV", "V", "VI", "VII", "VIII"]
-        ]
-        missing = [
-            p for p in required if not os.path.isfile(os.path.join(templates_dir, p))
-        ]
-        if missing:
-            raise FileNotFoundError(
-                f"Brak plików w {templates_dir}: {', '.join(missing)}"
-            )
-        self.tm = TemplateMatcher(templates_dir)
-        self.reader = easyocr.Reader(["pl", "en"], gpu=False) if use_ocr else None
         self.dry = dry
-        self.keys = KeyHold(
-            dry=self.dry, active_fn=getattr(self.win, "is_foreground", None)
-        )
+        self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
+
         tp_cfg = self.cfg.teleport
         self.click_duration = tp_cfg.click_duration
         self.open_panel_delay = tp_cfg.open_panel_delay
-        self.page_thresh = tp_cfg.page_thresh
-        self.after_page_delay = tp_cfg.after_page_delay
         self.row_click_delay = tp_cfg.row_click_delay
-        self.load_btn_thresh = tp_cfg.load_btn_thresh
         self.after_load_delay = tp_cfg.after_load_delay
-
-    def _frame(self) -> np.ndarray:
-        fr = self.win.grab()
-        return np.array(fr)[:, :, :3].copy()
-
-    def _save_panel(self, frame: np.ndarray, reason: TeleportResult) -> None:
-        """Save current panel frame for debugging failures."""
-        try:
-            log_dir = self.cfg.paths.log_dir or "runs"
-            os.makedirs(log_dir, exist_ok=True)
-            fname = os.path.join(
-                log_dir, f"tp_fail_{reason.value}_{int(time.time())}.png"
-            )
-            Image.fromarray(frame).save(fname)
-            logger.debug("Teleport failure screenshot saved to %s", fname)
-        except Exception:
-            logger.debug("Could not save teleport failure screenshot", exc_info=True)
 
     def _safe_click(self, x: int, y: int) -> None:
         if self.dry:
@@ -120,236 +73,66 @@ class Teleporter:
         pyautogui.click()
 
     def open_panel(self, max_attempts: int = 3) -> bool:
-        """Open teleport panel and verify it appears.
-
-        Sends the ``Ctrl+X`` hotkey, takes a screenshot and checks whether any
-        of the page templates (``strona_I.png`` .. ``strona_VIII.png``) is
-        visible.  For each template the check is performed first with
-        :class:`TemplateMatcher` and then, if needed, with
-        :func:`pyautogui.locateOnScreen`.  The function returns as soon as a
-        template matches.  When the panel is not detected the hotkey is retried
-        ``max_attempts`` times before raising :class:`RuntimeError`.
-        """
+        """Open teleport panel using ``Ctrl+X`` without any verification."""
 
         self.win.focus()
         if not self.win.is_foreground():
             logger.debug("Window is not in foreground before opening teleport panel")
             return False
 
-        L, T, w, h = self.win.region
-        roi = (
-            0,
-            int(h * 0.80),
-            w,
-            int(h * 0.20),
-        )
-        screen_roi = (L + roi[0], T + roi[1], roi[2], roi[3])
-        page_refs = [
-            f"strona_{r}" for r in ["I", "II", "III", "IV", "V", "VI", "VII", "VIII"]
-        ]
-        logger.debug(
-            "open_panel setup: region=%s ROI=%s screen_roi=%s templates=%s thresh=%.3f",
-            self.win.region,
-            roi,
-            screen_roi,
-            page_refs,
-            self.page_thresh,
-        )
-
-        frame = None
         for attempt in range(max_attempts):
-            if not self.win.is_foreground():
-                logger.debug("Window not in foreground on attempt %d", attempt + 1)
             logger.debug("Attempt %d to open teleport panel", attempt + 1)
             if not self.dry:
                 self.keys.hotkey(["ctrl", "x"], duration=0.05)
-            else:
-                return True
             time.sleep(self.open_panel_delay)
-
-            frame = self._frame()
-            logger.debug(
-                "Captured frame shape: %s", None if frame is None else frame.shape
-            )
             if not self.win.is_foreground():
                 logger.debug(
                     "Window lost foreground after keypress on attempt %d", attempt + 1
                 )
-
-            found = None
-            for ref_name in page_refs:
-                template_path = self.tm.dir / f"{ref_name}.png"
-                found = self.tm.find(
-                    frame,
-                    ref_name,
-                    thresh=self.page_thresh,
-                    roi=roi,
-                    multi_scale=True,
-                )
-                if found:
-                    logger.debug(
-                        "TemplateMatcher found %s on attempt %d", ref_name, attempt + 1
-                    )
-                    return True
-                logger.debug(
-                    "TemplateMatcher did not find %s; falling back to pyautogui.locateOnScreen",
-                    ref_name,
-                )
-                try:
-                    template_img = Image.open(template_path)
-                    tw, th = template_img.size
-                    sr_w, sr_h = screen_roi[2], screen_roi[3]
-                    if tw > sr_w or th > sr_h:
-                        scale = min(sr_w / tw, sr_h / th)
-                        if scale < 1:
-                            new_size = (
-                                max(1, int(tw * scale)),
-                                max(1, int(th * scale)),
-                            )
-                            template_img = template_img.resize(new_size, Image.LANCZOS)
-                            logger.debug(
-                                "Resized template %s from (%d, %d) to %s to fit region %s",
-                                ref_name,
-                                tw,
-                                th,
-                                new_size,
-                                screen_roi,
-                            )
-                    found = pyautogui.locateOnScreen(
-                        template_img,
-                        region=screen_roi,
-                        confidence=self.page_thresh,
-                    )
-                    logger.debug(
-                        "pyautogui.locateOnScreen result for %s: %s", ref_name, found
-                    )
-                except Exception:
-                    logger.debug(
-                        "pyautogui.locateOnScreen raised exception for %s", ref_name, exc_info=True
-                    )
-                    found = None
-                if found:
-                    logger.debug(
-                        "Teleport panel detected via pyautogui for %s on attempt %d",
-                        ref_name,
-                        attempt + 1,
-                    )
-                    return True
-            logger.debug("Teleport panel not detected on attempt %d", attempt + 1)
-
-        logger.warning("Teleport panel not detected after %d attempts", max_attempts)
-        if frame is not None:
-            self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
-        raise RuntimeError("Teleport panel not detected")
+                return False
+            return True
+        return True
 
     def close_panel(self) -> None:
         """Close the teleport panel if it is open."""
+
         if self.dry:
             return
         self.keys.tap("esc")
 
-    def go_page(self, page_label: str, thresh: float | None = None) -> bool:
-        token = page_label.split()[-1].upper().replace(" ", "_")
-        name = f"strona_{token}"
-        _, _, w, h = self.win.region
-        roi = (int(w * 0.05), int(h * 0.82), int(w * 0.9), int(h * 0.16))
-        frame = self._frame()
-        m = self.tm.find(
-            frame, name, thresh=thresh or self.page_thresh, roi=roi, multi_scale=True
-        )
-        if not m:
-            return False
-        L, T, _, _ = self.win.region
-        cx, cy = m.center
-        self._safe_click(L + cx, T + cy)
-        time.sleep(self.after_page_delay)
-        return True
+    # ---- teleportation ----
+    def teleport_slot(self, slot: int, page_label: str | None = None) -> TeleportResult:
+        """Teleport to the configured ``slot``.
 
-    def _find_row_by_text(self, target_text: str):
-        frame = self._frame()
-        h, w = frame.shape[:2]
-        roi = frame[int(h * 0.16) : int(h * 0.70), int(w * 0.05) : int(w * 0.55)]
-        if self.reader is None:
-            return None
-        results = self.reader.readtext(roi)
-        target_low = target_text.lower().strip()
-        for bbox, text, _ in results:
-            if text.lower().strip() == target_low:
-                (x0, y0), (x1, y1) = bbox[0], bbox[2]
-                return int((x0 + x1) // 2), int((y0 + y1) // 2)
-        return None
-
-    # ---- teleportacja ----
-    def teleport_slot(self, slot: int, page_label: str) -> TeleportResult:
-        """Teleport to ``slot`` on ``page_label``.
-
-        Returns :class:`TeleportResult` describing the outcome of the
-        attempt. On failure a screenshot of the panel is saved to
-        ``runs/`` (or the directory specified by ``paths.log_dir`` in the
-        configuration).
-
-        PL:
-        Teleportuj do danego numeru slotu na podanej stronie.
-
-        Zwraca :class:`TeleportResult` opisujący rezultat próby
-        teleportacji.  Przy niepowodzeniu zrzut panelu jest zapisywany w
-        ``runs/`` (lub w katalogu wskazanym przez ``paths.log_dir`` w
-        konfiguracji).
+        ``page_label`` is accepted for backwards compatibility but ignored.
+        Coordinates are loaded from ``config/teleport.yaml``.
         """
 
-        logger.debug("Teleporting to slot %s on page '%s'", slot, page_label)
-        # otwórz panel i przejdź do strony
-        try:
-            self.open_panel()
-        except RuntimeError:
-            frame = self._frame()
-            self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
-            return TeleportResult.TEMPLATE_NOT_FOUND
-        if not self.win.is_foreground():
+        logger.debug("Teleporting to slot %s via coordinates", slot)
+        if not self.open_panel():
             return TeleportResult.WINDOW_NOT_FOREGROUND
-        if not self.go_page(page_label):
-            logger.info("Page '%s' not found", page_label)
-            frame = self._frame()
-            self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
+
+        cfg = tc.get_config()
+        positions = cfg.positions
+        if slot < 1 or slot > len(positions):
+            logger.info("Slot %s not configured", slot)
             return TeleportResult.TEMPLATE_NOT_FOUND
 
-        # wyszukaj wiersz slotu (OCR)
-        pos = self._find_row_by_text(str(slot))
-        if pos is None:
-            logger.info("Slot '%s' not found via OCR", slot)
-            frame = self._frame()
-            self._save_panel(frame, TeleportResult.OCR_MISS)
-            return TeleportResult.OCR_MISS
-
-        # przekształć współrzędne z ROI na współrzędne ekranu
-        L, T, w, h = self.win.region
-        roi_x = int(w * 0.05)
-        roi_y = int(h * 0.16)
-        abs_x = L + roi_x + pos[0]
-        abs_y = T + roi_y + pos[1]
-        logger.debug("Clicking teleport slot at (%d, %d)", abs_x, abs_y)
-        self._safe_click(abs_x, abs_y)
+        x, y = positions[slot - 1]
+        logger.debug("Clicking teleport slot at (%d, %d)", x, y)
+        self._safe_click(x, y)
         time.sleep(self.row_click_delay)
-
-        # przycisk "wczytaj"
-        frame = self._frame()
-        m = self.tm.find(
-            frame, "wczytaj", thresh=self.load_btn_thresh, multi_scale=True
-        )
-        if not m:
-            logger.info("Load button not found for slot %s", slot)
-            self._save_panel(frame, TeleportResult.TEMPLATE_NOT_FOUND)
-            return TeleportResult.TEMPLATE_NOT_FOUND
-        cx, cy = m.center
-        logger.debug("Clicking load button at (%d, %d)", L + cx, T + cy)
-        self._safe_click(L + cx, T + cy)
+        if not self.dry:
+            self.keys.tap("e")
         time.sleep(self.after_load_delay)
         logger.info("Teleportation to slot %s successful", slot)
         return TeleportResult.OK
 
-    def teleport(self, slot: int, page_label: str) -> TeleportResult:
-        """Compatibility wrapper named ``teleport``.
+    def teleport(self, slot: int, page_label: str | None = None) -> TeleportResult:
+        """Compatibility wrapper named ``teleport``."""
 
-        PL: Zachowana dla kompatybilności nazwa ``teleport``.
-        """
         return self.teleport_slot(slot, page_label)
+
+
+__all__ = ["Teleporter", "TeleportResult"]
+

--- a/tests/test_teleport_close_panel.py
+++ b/tests/test_teleport_close_panel.py
@@ -28,23 +28,11 @@ _pydantic.BaseModel = _BaseModel
 _pydantic.Field = _Field
 sys.modules.setdefault("pydantic", _pydantic)
 
-# Stub easyocr to avoid heavy import
-sys.modules.setdefault("easyocr", types.SimpleNamespace(Reader=lambda *a, **k: None))
-
-# Provide a minimal numpy stub for imports
-sys.modules.setdefault("numpy", types.ModuleType("numpy"))
-
-# Stub PIL.Image used for saving screenshots
-PIL_stub = types.ModuleType("PIL")
-PIL_stub.Image = types.SimpleNamespace()
-sys.modules.setdefault("PIL", PIL_stub)
-
 # Stub pyautogui to avoid real key presses
 pyautogui_stub = types.SimpleNamespace(
     moveTo=lambda *a, **k: None,
     click=lambda *a, **k: None,
     press=lambda *a, **k: None,
-    locateOnScreen=lambda *a, **k: None,
     PAUSE=0,
 )
 sys.modules.setdefault("pyautogui", pyautogui_stub)
@@ -61,16 +49,6 @@ wc_mod.WindowCapture = WindowCapture
 recorder_pkg.window_capture = wc_mod
 sys.modules.setdefault("recorder", recorder_pkg)
 sys.modules.setdefault("recorder.window_capture", wc_mod)
-
-# Stub agent.template_matcher used during import
-tm_stub = types.ModuleType("agent.template_matcher")
-
-class _TM:
-    def __init__(self, *a, **k):
-        pass
-
-tm_stub.TemplateMatcher = _TM
-sys.modules.setdefault("agent.template_matcher", tm_stub)
 
 sys.modules.pop("agent.teleport", None)
 from agent.teleport import Teleporter

--- a/tests/test_teleport_open_panel.py
+++ b/tests/test_teleport_open_panel.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import types
-from pathlib import Path
 
 # Ensure repository root on path and stub optional dependencies
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,50 +13,28 @@ sys.modules.setdefault("yaml", yaml_stub)
 # Minimal pydantic stub providing BaseModel and Field
 _pydantic = types.ModuleType("pydantic")
 
-class _BaseModel:
+
+class _BaseModel:  # pragma: no cover - simple stub
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-def _Field(default=None, default_factory=None, **kwargs):
+
+def _Field(default=None, default_factory=None, **kwargs):  # pragma: no cover
     if default_factory is not None:
         return default_factory()
     return default
 
+
 _pydantic.BaseModel = _BaseModel
 _pydantic.Field = _Field
 sys.modules.setdefault("pydantic", _pydantic)
-
-# Stub easyocr to avoid heavy import
-sys.modules.setdefault("easyocr", types.SimpleNamespace(Reader=lambda *a, **k: None))
-
-# Provide a minimal numpy stub for imports
-sys.modules.setdefault("numpy", types.ModuleType("numpy"))
-
-# Stub PIL.Image used for image operations
-class _FakeImage:
-    def __init__(self, size):
-        self.size = size
-
-    def resize(self, size, resample=None):
-        return _FakeImage(size)
-
-
-def _fake_open(path):  # pylint: disable=unused-argument
-    return _FakeImage(_fake_open.size)
-
-
-PIL_stub = types.ModuleType("PIL")
-PIL_stub.Image = types.SimpleNamespace(open=_fake_open, LANCZOS=0)
-sys.modules.setdefault("PIL", PIL_stub)
-_fake_open.size = (10, 10)
 
 # Stub pyautogui to avoid real key presses
 pyautogui_stub = types.SimpleNamespace(
     moveTo=lambda *a, **k: None,
     click=lambda *a, **k: None,
     press=lambda *a, **k: None,
-    locateOnScreen=lambda *a, **k: None,
     PAUSE=0,
 )
 sys.modules.setdefault("pyautogui", pyautogui_stub)
@@ -67,95 +44,82 @@ recorder_pkg = types.ModuleType("recorder")
 recorder_pkg.__path__ = []
 wc_mod = types.ModuleType("recorder.window_capture")
 
-class WindowCapture:
+
+class WindowCapture:  # pragma: no cover - minimal stub
     pass
+
 
 wc_mod.WindowCapture = WindowCapture
 recorder_pkg.window_capture = wc_mod
 sys.modules.setdefault("recorder", recorder_pkg)
 sys.modules.setdefault("recorder.window_capture", wc_mod)
 
-# Stub agent.template_matcher used during import
-tm_stub = types.ModuleType("agent.template_matcher")
-
-class _TM:
-    def __init__(self, *a, **k):
-        pass
-
-tm_stub.TemplateMatcher = _TM
-sys.modules.setdefault("agent.template_matcher", tm_stub)
-
 sys.modules.pop("agent.teleport", None)
-from agent.teleport import Teleporter
+from agent.teleport import Teleporter, TeleportResult
 
 
-def test_open_panel_detects_non_first_page():
+def test_open_panel_sends_hotkey_and_returns_true():
     teleporter = Teleporter.__new__(Teleporter)
     teleporter.dry = False
-    hotkey_calls: list[tuple[list[str], float]] = []
+    calls: list[tuple[list[str], float]] = []
 
     def _hotkey(keys, duration=0.05):
-        hotkey_calls.append((keys, duration))
+        calls.append((keys, duration))
 
     teleporter.keys = types.SimpleNamespace(hotkey=_hotkey)
     teleporter.open_panel_delay = 0
-    teleporter.page_thresh = 0.5
     teleporter.win = types.SimpleNamespace(
         focus=lambda: None,
         is_foreground=lambda: True,
-        region=(0, 0, 100, 100),
     )
-    teleporter._frame = lambda: types.SimpleNamespace(shape=(1, 1, 3))
-
-    call_order = []
-
-    class TM:
-        dir = Path(".")
-
-        def find(self, frame, name, thresh, roi, multi_scale):
-            call_order.append(name)
-            if name == "strona_II":
-                return object()
-            return None
-
-    teleporter.tm = TM()
 
     assert teleporter.open_panel() is True
-    assert hotkey_calls == [(["ctrl", "x"], 0.05)]
-    assert call_order[:2] == ["strona_I", "strona_II"]
+    assert calls == [(["ctrl", "x"], 0.05)]
 
 
-def test_open_panel_scales_large_template():
+def test_open_panel_returns_false_when_not_foreground():
     teleporter = Teleporter.__new__(Teleporter)
     teleporter.dry = False
     teleporter.keys = types.SimpleNamespace(hotkey=lambda *a, **k: None)
     teleporter.open_panel_delay = 0
-    teleporter.page_thresh = 0.5
     teleporter.win = types.SimpleNamespace(
         focus=lambda: None,
-        is_foreground=lambda: True,
-        region=(0, 0, 100, 100),
+        is_foreground=lambda: False,
     )
-    teleporter._frame = lambda: types.SimpleNamespace(shape=(1, 1, 3))
 
-    class TM:
-        dir = Path(".")
+    assert teleporter.open_panel() is False
 
-        def find(self, frame, name, thresh, roi, multi_scale):  # noqa: ARG002
-            return None
 
-    teleporter.tm = TM()
+def test_teleport_slot_uses_configured_coordinates():
+    import agent.teleport_config as tc
 
-    # simulate template larger than search region
-    _fake_open.size = (120, 30)
+    orig = tc.get_config
 
-    calls: list[tuple[tuple[int, int], tuple[int, int, int, int]]] = []
+    class _Cfg:
+        delay_after_panel = 0
+        delay_after_teleport = 0
+        positions = [(10, 20), (30, 40)]
 
-    def _locate(template, region=None, confidence=None):  # noqa: ARG001
-        calls.append((template.size, region))
-        return object()
+    tc.get_config = lambda *a, **k: _Cfg()
 
-    pyautogui_stub.locateOnScreen = _locate
+    teleporter = Teleporter.__new__(Teleporter)
+    teleporter.dry = False
+    teleporter.open_panel_delay = 0
+    teleporter.row_click_delay = 0
+    teleporter.after_load_delay = 0
+    teleporter.open_panel = lambda *a, **k: True
+    calls = []
 
-    assert teleporter.open_panel() is True
-    assert calls == [((80, 20), (0, 80, 100, 20))]
+    def _safe_click(x, y):
+        calls.append(("click", x, y))
+
+    teleporter._safe_click = _safe_click  # type: ignore
+    teleporter.keys = types.SimpleNamespace(tap=lambda k: calls.append(("tap", k)))
+
+    res = teleporter.teleport_slot(2, None)
+
+    assert res is TeleportResult.OK
+    assert calls == [("click", 30, 40), ("tap", "e")]
+
+    tc.get_config = orig
+


### PR DESCRIPTION
## Summary
- Replace template/OCR logic with simple coordinate-driven teleporting
- Add unit test ensuring teleporter clicks configured coordinates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c019a9ee2883309c78222c17712317