### PR TITLE
Add Start Polowania button to GUI

### DIFF
--- a/gui/i18n/en.ts
+++ b/gui/i18n/en.ts
@@ -185,23 +185,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="252"/>
-        <location filename="../main_window.py" line="491"/>
-        <location filename="../main_window.py" line="936"/>
-        <source>Teleportuj i poluj</source>
+        <location filename="../main_window.py" line="541"/>
+        <location filename="../main_window.py" line="821"/>
+        <source>Start polowania</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="254"/>
-        <location filename="../main_window.py" line="492"/>
+        <location filename="../main_window.py" line="546"/>
+        <location filename="../main_window.py" line="824"/>
         <location filename="../main_window.py" line="956"/>
         <location filename="../main_window.py" line="983"/>
         <source>Cykl 8×8 (sloty×kanały)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="256"/>
-        <location filename="../main_window.py" line="493"/>
+        <location filename="../main_window.py" line="548"/>
+        <location filename="../main_window.py" line="825"/>
         <location filename="../main_window.py" line="993"/>
         <location filename="../main_window.py" line="1037"/>
         <source>Zmień kanał</source>
@@ -422,7 +421,7 @@
     </message>
     <message>
         <location filename="../main_window.py" line="920"/>
-        <source>Zakończono &apos;Teleportuj i poluj&apos;.</source>
+        <source>Zakończono polowanie.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -432,17 +431,17 @@
     </message>
     <message>
         <location filename="../main_window.py" line="930"/>
-        <source>Błąd teleport+poluj: {exc}</source>
+        <source>Błąd polowania: {exc}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main_window.py" line="941"/>
-        <source>Stop &apos;Teleportuj i poluj&apos;</source>
+        <source>Stop polowania</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main_window.py" line="942"/>
-        <source>Teleportuję i poluję…</source>
+        <source>Rozpoczynam polowanie…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/i18n/pl.ts
+++ b/gui/i18n/pl.ts
@@ -185,23 +185,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="252"/>
-        <location filename="../main_window.py" line="491"/>
-        <location filename="../main_window.py" line="936"/>
-        <source>Teleportuj i poluj</source>
+        <location filename="../main_window.py" line="541"/>
+        <location filename="../main_window.py" line="821"/>
+        <source>Start polowania</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="254"/>
-        <location filename="../main_window.py" line="492"/>
+        <location filename="../main_window.py" line="546"/>
+        <location filename="../main_window.py" line="824"/>
         <location filename="../main_window.py" line="956"/>
         <location filename="../main_window.py" line="983"/>
         <source>Cykl 8×8 (sloty×kanały)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main_window.py" line="256"/>
-        <location filename="../main_window.py" line="493"/>
+        <location filename="../main_window.py" line="548"/>
+        <location filename="../main_window.py" line="825"/>
         <location filename="../main_window.py" line="993"/>
         <location filename="../main_window.py" line="1037"/>
         <source>Zmień kanał</source>
@@ -422,7 +421,7 @@
     </message>
     <message>
         <location filename="../main_window.py" line="920"/>
-        <source>Zakończono &apos;Teleportuj i poluj&apos;.</source>
+        <source>Zakończono polowanie.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -432,17 +431,17 @@
     </message>
     <message>
         <location filename="../main_window.py" line="930"/>
-        <source>Błąd teleport+poluj: {exc}</source>
+        <source>Błąd polowania: {exc}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main_window.py" line="941"/>
-        <source>Stop &apos;Teleportuj i poluj&apos;</source>
+        <source>Stop polowania</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main_window.py" line="942"/>
-        <source>Teleportuję i poluję…</source>
+        <source>Rozpoczynam polowanie…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -538,6 +538,10 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         )
         self.btn_agent.setCheckable(True)
+        self.btn_hunt = QtWidgets.QPushButton(
+            QtCore.QCoreApplication.translate("MainWindow", "Start polowania")
+        )
+        self.btn_hunt.setCheckable(True)
         self.btn_cycle = QtWidgets.QPushButton(
             QtCore.QCoreApplication.translate("MainWindow", "Cykl 8×8 (sloty×kanały)")
         )
@@ -565,6 +569,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.btn_preview,
             self.btn_record,
             self.btn_agent,
+            self.btn_hunt,
             self.btn_cycle,
             self.btn_ch,
             self.btn_stop,
@@ -691,6 +696,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_preview.toggled.connect(self.toggle_preview)
         self.btn_record.toggled.connect(self.record_data)
         self.btn_agent.toggled.connect(self.start_agent)
+        self.btn_hunt.toggled.connect(self.start_hunt)
         self.btn_cycle.toggled.connect(self.start_cycle)
         self.btn_ch.toggled.connect(self.change_channel)
         self.btn_stop.clicked.connect(self.stop_all)
@@ -811,6 +817,9 @@ class MainWindow(QtWidgets.QMainWindow):
             QtCore.QCoreApplication.translate(
                 "MainWindow", "Start agenta (YOLO + WASD)"
             )
+        )
+        self.btn_hunt.setText(
+            QtCore.QCoreApplication.translate("MainWindow", "Start polowania")
         )
         self.btn_cycle.setText(
             QtCore.QCoreApplication.translate("MainWindow", "Cykl 8×8 (sloty×kanały)")
@@ -1172,6 +1181,31 @@ class MainWindow(QtWidgets.QMainWindow):
             QtCore.QCoreApplication.translate("MainWindow", "Start cyklu 8×8…")
         )
 
+    def start_hunt(self, checked: bool) -> None:
+        if checked:
+            try:
+                if not self.btn_preview.isChecked():
+                    self.btn_preview.setChecked(True)
+                if not self.btn_agent.isChecked():
+                    self.btn_agent.setChecked(True)
+                if not self.btn_cycle.isChecked():
+                    self.btn_cycle.setChecked(True)
+                self.btn_hunt.setText(
+                    QtCore.QCoreApplication.translate(
+                        "MainWindow", "Stop polowania"
+                    )
+                )
+            except Exception:
+                self.btn_hunt.setChecked(False)
+                self.stop_all()
+        else:
+            self.stop_all()
+            self.btn_hunt.setText(
+                QtCore.QCoreApplication.translate(
+                    "MainWindow", "Start polowania"
+                )
+            )
+
     def change_channel(self, checked: bool) -> None:
         if not checked:
             self.btn_ch.setText(
@@ -1235,6 +1269,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.btn_preview,
             self.btn_record,
             self.btn_agent,
+            self.btn_hunt,
             self.btn_cycle,
             self.btn_ch,
             self.btn_run_rl,


### PR DESCRIPTION
## Summary
- Add `Start polowania` hunt button to the main window and wire it to start preview, agent, and cycle threads.
- Implement `start_hunt` to toggle required threads and stop all on errors.
- Update Polish and English translation files with hunt strings.

## Testing
- `python -m py_compile gui/main_window.py`
- `QT_QPA_PLATFORM=offscreen python gui/app.py` *(fails: libGL.so.1: cannot open shared object file)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c056ce45a08330bf05b4f969a2b700