### PR TITLE
Ensure channel switches after set number of teleports

### DIFF
--- a/agent/search.py
+++ b/agent/search.py
@@ -58,7 +58,14 @@ class SearchManager:
                 self.teleporter.teleport_slot(slot, self.tp_page)
                 self._teleports += 1
                 self.location_idx = (self.location_idx + 1) % len(self.tp_slots)
-                if self._teleports % self.channel_every == 0 or self.location_idx == 0:
+                # Change channel only after completing the configured number of
+                # teleports.  Previously the channel was also switched whenever
+                # the teleport slot index wrapped around which caused a channel
+                # change after every cycle of available slots (e.g. after two
+                # teleports when only two slots were configured).  The new logic
+                # matches the requirement to switch channels strictly after the
+                # specified number of position changes.
+                if self._teleports % self.channel_every == 0:
                     if self.channels:
                         ch = self.channels[self.channel_idx % len(self.channels)]
                         try:

--- a/tests/test_search_manager.py
+++ b/tests/test_search_manager.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub out heavy dependencies required by agent.channel and agent.teleport
+teleport_mod = types.ModuleType("agent.teleport")
+
+
+class _StubTeleporter:
+    def __init__(self, *a, **k):
+        pass
+
+
+teleport_mod.Teleporter = _StubTeleporter
+sys.modules.setdefault("agent.teleport", teleport_mod)
+
+channel_mod = types.ModuleType("agent.channel")
+
+
+class _StubChannelSwitcher:
+    def __init__(self, *a, **k):
+        pass
+
+    def switch(self, *a, **k):
+        pass
+
+
+channel_mod.ChannelSwitcher = _StubChannelSwitcher
+sys.modules.setdefault("agent.channel", channel_mod)
+
+from agent.search import SearchManager
+
+class DummyTeleporter:
+    def __init__(self):
+        self.calls = 0
+
+    def teleport_slot(self, slot, page):
+        self.calls += 1
+
+
+class DummyChannelSwitcher:
+    def __init__(self):
+        self.switched = []
+
+    def switch(self, ch):
+        self.switched.append(ch)
+
+
+def test_switch_channel_after_configured_teleports():
+    teleporter = DummyTeleporter()
+    channel = DummyChannelSwitcher()
+    # no_target_sec < 0 ensures the teleportation branch is always taken
+    manager = SearchManager(
+        teleporter,
+        channel,
+        tp_slots=[1],
+        tp_page=None,
+        channels=[1, 2],
+        no_target_sec=-1,
+        channel_every=8,
+    )
+
+    # perform 7 teleports - channel should not change yet
+    for _ in range(7):
+        manager.handle_no_target(True)
+    assert channel.switched == []
+
+    # 8th teleport triggers channel switch
+    manager.handle_no_target(True)
+    assert channel.switched == [1]


### PR DESCRIPTION
## Summary
- prevent premature channel changes by switching only after the configured teleport count
- add unit test verifying channel change after eight teleports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05c3fe3e483308a0a6afb79737cc0