### PR TITLE
Log expected errors when stopping cycle

### DIFF
--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -97,15 +97,22 @@ class CycleFarm:
         self.cooldown_min = int(cfg.cooldowns.slot_min)
 
     def stop(self):
+        """Stop agent components gracefully.
+
+        Only expected errors from the underlying helpers are swallowed. Any
+        such errors are logged for debugging instead of silenced.
+        """
         self._stop = True
+
         try:
             self.keys.stop()
-        except Exception:
-            pass
+        except (RuntimeError, OSError) as exc:
+            logger.exception("Błąd podczas zatrzymywania klawiszy: %s", exc)
+
         try:
             self.win.close()
-        except Exception:
-            pass
+        except (RuntimeError, OSError) as exc:
+            logger.exception("Błąd podczas zamykania okna: %s", exc)
 
     # ---- detekcje ----
     def _any_target_seen(self) -> bool:


### PR DESCRIPTION
## Summary
- Narrow CycleFarm.stop error handling to expected runtime and OS errors
- Log failures from KeyHold.stop and WindowCapture.close

## Testing
- `python -m py_compile agent/cycle.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- Manual: forced KeyHold and window close errors -> logged via logger


------
https://chatgpt.com/codex/tasks/task_e_68c0744afcc88330b008d288bbfaff2a