### PR TITLE
feat: delegate strategy cleanup in CycleFarm

### DIFF
--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -99,10 +99,21 @@ class CycleFarm:
     def stop(self):
         """Stop agent components gracefully.
 
-        Only expected errors from the underlying helpers are swallowed. Any
-        such errors are logged for debugging instead of silenced.
+        Delegates cleanup to the loaded strategy when it exposes a ``stop``
+        method. Only expected errors from the underlying helpers are
+        swallowed. Any such errors are logged for debugging instead of
+        silenced.
         """
         self._stop = True
+
+        stop_fn = getattr(self.agent, "stop", None)
+        if callable(stop_fn):
+            try:
+                stop_fn()
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.exception(
+                    "Błąd podczas zatrzymywania strategii: %s", exc
+                )
 
         try:
             self.keys.stop()


### PR DESCRIPTION
## Summary
- delegate `CycleFarm.stop` cleanup to loaded strategy
- log strategy stop errors rather than swallowing them

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c10b1bb6fc8330b8246718dcfac7ad