### PR TITLE
feat: add stop hook to strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ WasdVisionAgent(cfg).run()
 PY
 ```
 
+### Strategy Lifecycle
+Custom automation strategies implement three lifecycle hooks:
+
+- `setup(cfg, window_capture)` – initialise resources.
+- `step()` – perform a single iteration of the strategy.
+- `stop()` – release any held resources. This method is called when the
+  agent shuts down and should be safe to invoke multiple times.
+
+Calling `stop()` ensures that windows, keyboard handlers and other helpers are
+cleanly closed.
+
 ## Configuration
 All runtime options live in [`config/agent.yaml`](config/agent.yaml).  Key fields include:
 

--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -9,7 +9,7 @@ import numpy as np
 from agent import AgentConfig, get_config
 from agent.channel import ChannelSwitcher
 from agent.detector import ObjectDetector
-from agent.strategy import load_strategy
+from agent.strategy import AgentStrategy, load_strategy
 from agent.scanner import AreaScanner
 from agent.teleport import Teleporter
 from agent.wasd import KeyHold
@@ -55,7 +55,7 @@ class CycleFarm:
             keys=self.keys,
             hotkeys=cfg.channel.hotkeys,
         )
-        self.agent = load_strategy(cfg, self.win)
+        self.agent: AgentStrategy = load_strategy(cfg, self.win)
         self.det = ObjectDetector(
             cfg.paths.model, cfg.detector.classes, cv2_threads=cfg.detector.cv2_threads
         )
@@ -99,21 +99,18 @@ class CycleFarm:
     def stop(self):
         """Stop agent components gracefully.
 
-        Delegates cleanup to the loaded strategy when it exposes a ``stop``
-        method. Only expected errors from the underlying helpers are
-        swallowed. Any such errors are logged for debugging instead of
-        silenced.
+        Delegates cleanup to the loaded strategy. Only expected errors from
+        the underlying helpers are swallowed. Any such errors are logged for
+        debugging instead of silenced.
         """
         self._stop = True
 
-        stop_fn = getattr(self.agent, "stop", None)
-        if callable(stop_fn):
-            try:
-                stop_fn()
-            except Exception as exc:  # pragma: no cover - best effort cleanup
-                logger.exception(
-                    "Błąd podczas zatrzymywania strategii: %s", exc
-                )
+        try:
+            self.agent.stop()
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            logger.exception(
+                "Błąd podczas zatrzymywania strategii: %s", exc
+            )
 
         try:
             self.keys.stop()

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -162,7 +162,7 @@ class HuntDestroy(AgentStrategy):
             self.movement.move(tgt, steer, (W, H))
         self._last_tgt = tgt
 
-    def stop(self):
+    def stop(self) -> None:
         """Release resources held by the strategy.
 
         The method may be invoked multiple times.  Missing attributes or

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -8,7 +8,7 @@ import numpy as np
 from recorder.window_capture import WindowCapture
 
 from . import AgentConfig, TeleportSlot
-from .strategy import load_strategy
+from .strategy import AgentStrategy, load_strategy
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class WasdVisionAgent:
         self.teleport_slots = list(cfg.teleport.slots)
         self.win = WindowCapture(cfg.window.title_substr)
         self.period = 1 / 15
-        self.hd = None
+        self.hd: AgentStrategy | None = None
 
     # ------------------------------------------------------------------
     # Public mutators allowing user customisation
@@ -52,14 +52,11 @@ class WasdVisionAgent:
                 self.hd.step()
                 time.sleep(self.period)
         except KeyboardInterrupt:
+            logger.info("Agent interrupted by user")
+        finally:
             if self.hd:
                 try:
-                    self.hd.teleporter.close_panel()
-                except Exception as exc:
-                    logger.warning("Failed to close teleporter panel: %s", exc)
-                try:
-                    self.hd.keys.release_all()
-                except Exception as exc:
-                    logger.warning("Failed to release keys: %s", exc)
-        finally:
+                    self.hd.stop()
+                except Exception as exc:  # pragma: no cover - best effort cleanup
+                    logger.warning("Failed to stop strategy: %s", exc)
             self.win.close()

--- a/agent/strategy.py
+++ b/agent/strategy.py
@@ -17,6 +17,10 @@ class AgentStrategy(Protocol):
         """Execute a single step of the strategy."""
         ...
 
+    def stop(self) -> None:
+        """Release any resources held by the strategy."""
+        ...
+
 
 _STRATEGIES: Dict[str, Type[AgentStrategy]] = {}
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -17,7 +17,7 @@ from PySide6.QtCore import QSettings
 
 from agent.channel import ChannelSwitcher
 from agent.cycle import CycleFarm
-from agent.strategy import load_strategy
+from agent.strategy import AgentStrategy, load_strategy
 from agent.wasd import KeyHold
 from gui.preview import PreviewWorker
 from gui.teleport_config_dialog import TeleportConfigDialog
@@ -107,6 +107,7 @@ class AgentThread(QtCore.QThread):
 
     def run(self) -> None:  # pragma: no cover - GUI thread
         win = WindowCapture(self.cfg["window"]["title_substr"])
+        agent: AgentStrategy | None = None
         try:
             if not win.locate(timeout=5):
                 self.status.emit(
@@ -127,6 +128,11 @@ class AgentThread(QtCore.QThread):
                 ).format(exc=exc)
             )
         finally:
+            if agent is not None:
+                try:
+                    agent.stop()
+                except Exception:  # pragma: no cover - best effort cleanup
+                    pass
             win.close()
             self.finished.emit()
 

--- a/tests/test_cycle_sequence.py
+++ b/tests/test_cycle_sequence.py
@@ -14,9 +14,9 @@ def test_cycle_sequence(monkeypatch):
     sys.modules.setdefault("pygetwindow", types.SimpleNamespace(getAllWindows=lambda: []))
     sys.modules.setdefault("win32con", types.SimpleNamespace())
     sys.modules.setdefault("win32gui", types.SimpleNamespace())
-    sys.modules.setdefault(
-        "cv2", types.SimpleNamespace(TM_CCOEFF_NORMED=0, setNumThreads=lambda n: None)
-    )
+    sys.modules[
+        "cv2"
+    ] = types.SimpleNamespace(TM_CCOEFF_NORMED=0, setNumThreads=lambda n: None)
     sys.modules.setdefault("easyocr", types.SimpleNamespace())
     pil = types.ModuleType("PIL")
     pil_image = types.ModuleType("PIL.Image")
@@ -71,6 +71,9 @@ def test_cycle_sequence(monkeypatch):
             pass
 
         def step(self):
+            pass
+
+        def stop(self) -> None:
             pass
 
     class DummyDetector:


### PR DESCRIPTION
## Summary
- add `stop()` lifecycle hook to `AgentStrategy` and expose to implementations
- type-hint strategy usage so `stop()` is recognised
- document strategy lifecycle and ensure sample implementations clean up resources

## Testing
- `pytest tests/test_cycle_sequence.py tests/test_capture.py tests/test_keyhold.py tests/test_wasd_align.py -q`
- `pytest tests/test_template_matcher.py -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c10de164a48330893031575662c93d