### PR TITLE
feat: add configurable periodic key presses

### DIFF
--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -9,7 +9,7 @@ import numpy as np
 from . import AgentConfig, get_config
 from .avoid import CollisionAvoid
 from .channel import ChannelSwitcher
-from .detector import ObjectDetector, Detection
+from .detector import Detection, ObjectDetector
 from .interaction import click_bbox_center
 from .movement import MovementController
 from .scanner import AreaScanner
@@ -42,6 +42,8 @@ class HuntDestroy(AgentStrategy):
         self._last_tgt: Detection | None = None
         self._prev_names: set[str] = set()
         self._grab_lock = threading.Lock()
+        self.auto_press = None
+        self._next_auto_press = 0.0
         if cfg is not None or window_capture is not None:
             self.setup(cfg, window_capture)
 
@@ -99,10 +101,18 @@ class HuntDestroy(AgentStrategy):
         self.movement = MovementController(
             self.keys, self.desired_w, self.deadzone, enabled=move_enabled
         )
+        self.auto_press = cfg.auto_press
+        self._next_auto_press = time.monotonic() + cfg.auto_press.interval_sec
         self._last_tgt = None
         self._prev_names = set()
 
     def step(self):
+        ap_cfg = self.auto_press
+        if ap_cfg and ap_cfg.enabled:
+            now = time.monotonic()
+            if now >= self._next_auto_press:
+                self.keys.tap(ap_cfg.key)
+                self._next_auto_press = now + ap_cfg.interval_sec
         with self._grab_lock:
             fr = self.win.grab()
         frame = np.array(fr)[:, :, :3].copy()

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -32,6 +32,10 @@ scan:
   pause: 0.12
 cooldowns:
   slot_min: 10
+auto_press:
+  enabled: false
+  key: "i"
+  interval_sec: 60.0
 priority: ["boss","metin","potwory"]
 teleport:
   slots:

--- a/config/models.py
+++ b/config/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -62,6 +63,14 @@ class CooldownsConfig(BaseModel):
     slot_min: int = 10
 
 
+class AutoPressConfig(BaseModel):
+    """Configuration for periodic key presses."""
+
+    enabled: bool = False
+    key: str = "i"
+    interval_sec: float = 60.0
+
+
 class TeleportSlot(BaseModel):
     page: str
     slot: int
@@ -108,6 +117,7 @@ class AgentConfig(BaseModel):
     stuck: StuckConfig = Field(default_factory=StuckConfig)
     scan: ScanConfig = Field(default_factory=ScanConfig)
     cooldowns: CooldownsConfig = Field(default_factory=CooldownsConfig)
+    auto_press: AutoPressConfig = Field(default_factory=AutoPressConfig)
     priority: List[str] = Field(default_factory=lambda: ["boss", "metin", "potwory"])
     teleport: TeleportConfig = Field(default_factory=TeleportConfig)
     channels: List[int] = Field(default_factory=lambda: [1, 2, 3, 4, 5, 6, 7, 8])
@@ -126,6 +136,7 @@ __all__ = [
     "StuckConfig",
     "ScanConfig",
     "CooldownsConfig",
+    "AutoPressConfig",
     "TeleportConfig",
     "TeleportSlot",
     "ChannelConfig",

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -268,7 +268,13 @@ def test_scan_interrupt_on_target(monkeypatch):
         "detector": {"classes": [], "conf_thr": 0.5, "iou_thr": 0.5},
         "policy": {"desired_box_w": 0.2, "deadzone_x": 0.1},
         "dry_run": True,
-        "scan": {"enabled": True, "sweep_ms": 1, "sweeps": 50, "idle_sec": 0, "pause": 0.001},
+        "scan": {
+            "enabled": True,
+            "sweep_ms": 1,
+            "sweeps": 50,
+            "idle_sec": 0,
+            "pause": 0.001,
+        },
     }
 
     agent = hd.HuntDestroy(cfg, _DummyWin())
@@ -282,6 +288,7 @@ def test_scan_interrupt_on_target(monkeypatch):
     agent.step()  # target appears
     # wait briefly for scan thread to react to cancellation
     import time as _t
+
     for _ in range(100):
         if not agent.scanner.is_scanning():
             break
@@ -289,3 +296,38 @@ def test_scan_interrupt_on_target(monkeypatch):
     assert not agent.scanner.is_scanning()
     assert agent.search.calls == 1
     assert agent.search.spin_done_values == [False]
+
+
+def test_auto_press(monkeypatch):
+    monkeypatch.setattr(hd, "ObjectDetector", _EmptyDetector)
+    monkeypatch.setattr(hd, "CollisionAvoid", lambda: _DummyAvoid())
+
+    class _TapKeyHold:
+        def __init__(self, dry=False, active_fn=None):
+            self.tapped = []
+
+        def tap(self, key, duration=0.05):
+            self.tapped.append(key)
+
+        def release_all(self):
+            pass
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(hd, "KeyHold", _TapKeyHold)
+    monkeypatch.setattr(hd, "SearchManager", _StubSearch)
+
+    cfg = {
+        "paths": {"model": "", "templates_dir": ""},
+        "detector": {"classes": [], "conf_thr": 0.5, "iou_thr": 0.5},
+        "dry_run": True,
+        "scan": {"enabled": False},
+        "auto_press": {"enabled": True, "key": "f", "interval_sec": 0.0},
+    }
+
+    agent = hd.HuntDestroy(cfg, _DummyWin())
+
+    agent.step()
+    agent.step()
+    assert agent.keys.tapped == ["f", "f"]


### PR DESCRIPTION
## Summary
- allow configuration of a periodic key press via new `auto_press` settings
- trigger the configured key in `HuntDestroy` at the specified interval
- test that periodic key press is executed

## Testing
- `flake8 agent/hunt_destroy.py config/models.py tests/test_hunt_destroy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4a78b2b1483309df04461a80c72c4