### PR TITLE
Add utilities for right-clicking detected objects

### DIFF
--- a/agent/interaction.py
+++ b/agent/interaction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 
 import pyautogui
+import numpy as np
 
 try:  # avoid circular import during tests
     from recorder.window_capture import WindowCapture
@@ -24,7 +25,11 @@ def _rate_limit_ok() -> bool:
 
 
 def click_bbox_center(
-    bbox, region, rate_limit: bool = True, win: WindowCapture | None = None
+    bbox,
+    region,
+    rate_limit: bool = True,
+    win: WindowCapture | None = None,
+    button: str = "left",
 ) -> bool:
     """Click the centre of ``bbox`` within ``region`` if the window is active.
 
@@ -36,6 +41,8 @@ def click_bbox_center(
         Whether to limit the number of clicks per second.
     win: WindowCapture | None
         Optional window instance used to verify focus.
+    button: str
+        Mouse button to use (e.g. ``"left"`` or ``"right"``).
 
     Returns
     -------
@@ -57,17 +64,128 @@ def click_bbox_center(
 
     if not rate_limit or _rate_limit_ok():
         pyautogui.moveTo(cx, cy, duration=0)
-        pyautogui.click()
+        pyautogui.click(button=button)
         return True
     return False
 
 
-def burst_click(bbox, region, n=3, interval=0.08, win: WindowCapture | None = None):
+def burst_click(
+    bbox,
+    region,
+    n: int = 3,
+    interval: float = 0.08,
+    win: WindowCapture | None = None,
+    button: str = "left",
+):
     """Series of clicks within ``bbox`` while ensuring window focus.
+
+    Parameters
+    ----------
+    bbox, region: tuple
+        Target and region coordinates.
+    n: int
+        Number of clicks to perform.
+    interval: float
+        Delay between clicks in seconds.
+    win: WindowCapture | None
+        Optional window instance for focus verification.
+    button: str
+        Mouse button used for the clicks.
 
     PL: Seria kliknięć w ``bbox`` z zachowaniem bezpieczeństwa fokusu.
     """
     for _ in range(n):
-        if not click_bbox_center(bbox, region, rate_limit=False, win=win):
+        if not click_bbox_center(bbox, region, rate_limit=False, win=win, button=button):
             break
         time.sleep(interval)
+
+
+def right_click_bbox_center(
+    bbox,
+    region,
+    rate_limit: bool = True,
+    win: WindowCapture | None = None,
+) -> bool:
+    """Convenience wrapper performing a right click on ``bbox`` centre.
+
+    Parameters mirror :func:`click_bbox_center` but always use the right mouse
+    button.  Returns ``True`` when the click was executed.
+    """
+
+    return click_bbox_center(
+        bbox,
+        region,
+        rate_limit=rate_limit,
+        win=win,
+        button="right",
+    )
+
+
+def detect_and_right_click(
+    detector,
+    region,
+    *,
+    frame=None,
+    target_names: list[str] | None = None,
+    win: WindowCapture | None = None,
+    rate_limit: bool = True,
+    click_all: bool = False,
+) -> bool:
+    """Detect objects and right-click matching ones.
+
+    The frame to analyse can be provided explicitly via ``frame``.  If omitted
+    the function grabs the current window contents using ``win``.  Detection
+    results are iterated in the order returned by ``detector.infer`` and each
+    matching object is right-clicked.  Set ``click_all`` to ``True`` to interact
+    with all matches instead of stopping after the first click.
+
+    Parameters
+    ----------
+    detector:
+        Object with ``infer(frame)`` -> list of detections exposing ``name`` and
+        ``bbox``.
+    region: tuple
+        ``(left, top, width, height)`` used to translate detection coordinates to
+        screen space.
+    frame: np.ndarray or ``None``
+        Optional BGR image; if ``None`` and ``win`` is provided the image will be
+        captured from the window.
+    target_names: list[str] or ``None``
+        Detection names to click.  ``None`` matches all objects.
+    win: WindowCapture | None
+        Optional window instance for capture and focus verification.
+    rate_limit: bool
+        Forwarded to :func:`click_bbox_center`.
+    click_all: bool
+        Whether to click all matching detections.
+
+    Returns
+    -------
+    bool
+        ``True`` if at least one click was performed.
+
+    PL: Wykryj obiekty na klatce i kliknij prawym przyciskiem wszystkie pasujące
+    do ``target_names`` (domyślnie pierwszy znaleziony obiekt).
+    """
+
+    if frame is None:
+        if win is None:
+            raise ValueError("frame or win must be provided")
+        fr = win.grab()
+        frame = np.array(fr)[:, :, :3].copy()
+
+    dets = detector.infer(frame)
+    clicked = False
+    for d in dets:
+        if target_names is None or d.name in target_names:
+            ok = click_bbox_center(
+                d.bbox,
+                region,
+                rate_limit=rate_limit,
+                win=win,
+                button="right",
+            )
+            clicked = clicked or ok
+            if ok and not click_all:
+                break
+    return clicked

--- a/tests/test_interaction_right_click.py
+++ b/tests/test_interaction_right_click.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+import agent.interaction as inter
+
+
+def test_right_click_bbox_center(monkeypatch):
+    clicks = []
+    monkeypatch.setattr(inter.pyautogui, "moveTo", lambda *a, **k: None)
+    monkeypatch.setattr(
+        inter.pyautogui,
+        "click",
+        lambda *a, **k: clicks.append(k.get("button", "left")),
+    )
+    assert inter.right_click_bbox_center((0, 0, 10, 10), (0, 0, 100, 100))
+    assert clicks == ["right"]
+
+
+def test_detect_and_right_click(monkeypatch):
+    clicks = []
+    monkeypatch.setattr(inter.pyautogui, "moveTo", lambda *a, **k: None)
+    monkeypatch.setattr(
+        inter.pyautogui,
+        "click",
+        lambda *a, **k: clicks.append(k.get("button", "left")),
+    )
+
+    class DummyDetector:
+        def infer(self, frame):
+            return [SimpleNamespace(name="item", bbox=(0, 0, 10, 10))]
+
+    region = (0, 0, 100, 100)
+    frame = object()
+    assert inter.detect_and_right_click(
+        DummyDetector(),
+        region,
+        frame=frame,
+        target_names=["item"],
+        rate_limit=False,
+    )
+    assert clicks == ["right"]
+
+
+def test_detect_and_right_click_grabs_frame(monkeypatch):
+    clicks = []
+    monkeypatch.setattr(inter.pyautogui, "moveTo", lambda *a, **k: None)
+    monkeypatch.setattr(
+        inter.pyautogui,
+        "click",
+        lambda *a, **k: clicks.append(k.get("button", "left")),
+    )
+
+    class DummyDetector:
+        def infer(self, frame):
+            assert isinstance(frame, np.ndarray)
+            return [SimpleNamespace(name="item", bbox=(0, 0, 10, 10))]
+
+    class DummyWin:
+        def grab(self):
+            return np.zeros((1, 1, 3), dtype=np.uint8)
+
+        def focus(self):
+            pass
+
+        def is_foreground(self):
+            return True
+
+    region = (0, 0, 100, 100)
+    assert inter.detect_and_right_click(
+        DummyDetector(),
+        region,
+        target_names=["item"],
+        win=DummyWin(),
+        rate_limit=False,
+    )
+    assert clicks == ["right"]


### PR DESCRIPTION
## Summary
- allow choosing mouse button in `click_bbox_center` and `burst_click`
- add helpers to right-click bounding boxes and detections, now with optional frame capture and multi-click support
- cover right-click logic with unit tests, including window-grab path

## Testing
- `DISPLAY=:0 PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4a9dd2b2c8330968370c347dd5d88