### PR TITLE
feat: add central game controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ Custom automation strategies implement three lifecycle hooks:
 Calling `stop()` ensures that windows, keyboard handlers and other helpers are
 cleanly closed.
 
+### Game Controller
+`agent.game_controller` exposes a global ``controller`` instance that
+coordinates window focus and input.  It provides helpers like
+``click(x, y)`` and ``teleport(slot)`` and allows strategies to register
+callbacks for ``on_disconnect`` and ``on_death`` events via
+``add_on_disconnect`` / ``add_on_death``.
+Strategies may import the controller to perform low‑level actions or
+subscribe to these fail‑safe hooks.
+
 ## Configuration
 All runtime options live in [`config/agent.yaml`](config/agent.yaml).  Key fields include:
 

--- a/agent/game_controller.py
+++ b/agent/game_controller.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""High level game controller coordinating window focus and input.
+
+The :class:`GameController` centralises all interaction with the Metin2
+window. It owns a :class:`~agent.wasd.KeyHold` instance for keyboard events and
+provides a safe :meth:`click` method that focuses the window before emitting
+mouse actions. Strategies can register callbacks for disconnection or death
+via :meth:`add_on_disconnect` and :meth:`add_on_death`.
+
+Fail‑safe recovery helpers such as :meth:`teleport` and :meth:`relog` are
+exposed for strategies to reuse. ``relog`` releases all keys, invokes the
+registered callbacks and teleports to the first configured slot.
+"""
+
+from typing import Callable, List, TYPE_CHECKING
+import logging
+
+import pyautogui
+
+from recorder.window_capture import WindowCapture
+
+from . import AgentConfig, get_config
+from .wasd import KeyHold
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .teleport import Teleporter, TeleportResult
+else:  # pragma: no cover - runtime import inside property
+    Teleporter = None  # type: ignore
+    TeleportResult = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class GameController:
+    """Coordinate window focus, keyboard/mouse input and fail‑safe resets."""
+
+    def __init__(
+        self,
+        win: WindowCapture,
+        cfg: AgentConfig | dict | None = None,
+    ) -> None:
+        if cfg is None:
+            cfg = get_config()
+        elif isinstance(cfg, dict):
+            cfg = AgentConfig(**cfg)
+        self.cfg = cfg
+        self.win = win
+        self.dry = cfg.dry_run
+        pyautogui.PAUSE = cfg.controls.mouse_pause
+        self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
+        self._teleporter: Teleporter | None = None
+        self._on_disconnect: List[Callable[[], None]] = []
+        self._on_death: List[Callable[[], None]] = []
+
+    # ------------------------------------------------------------------
+    # basic window helpers
+    # ------------------------------------------------------------------
+    def focus(self) -> None:
+        """Bring the game window to the foreground."""
+        self.win.focus()
+
+    def is_foreground(self) -> bool:
+        """Return ``True`` when the game window is in the foreground."""
+        fn = getattr(self.win, "is_foreground", None)
+        return bool(fn()) if fn else True
+
+    # ------------------------------------------------------------------
+    # low level input helpers
+    # ------------------------------------------------------------------
+    def click(self, x: int, y: int, duration: float | None = None) -> None:
+        """Focus the window and click at ``(x, y)`` if not ``dry``."""
+        if self.dry:
+            return
+        self.focus()
+        if not self.is_foreground():
+            return
+        pyautogui.moveTo(x, y, duration=duration or self.cfg.teleport.click_duration)
+        pyautogui.click()
+
+    # ------------------------------------------------------------------
+    # fail‑safe helpers
+    # ------------------------------------------------------------------
+    @property
+    def teleporter(self) -> "Teleporter":
+        from .teleport import Teleporter  # local import to avoid cycle
+        if self._teleporter is None:
+            self._teleporter = Teleporter(self.win, cfg=self.cfg, controller=self)
+        return self._teleporter
+
+    def teleport(self, slot: int) -> "TeleportResult":
+        """Teleport using the configured :class:`Teleporter`."""
+        return self.teleporter.teleport_slot(slot)
+
+    def relog(self) -> None:
+        """Reset after a disconnect by teleporting to the first slot."""
+        self.keys.release_all()
+        for cb in list(self._on_disconnect):
+            try:
+                cb()
+            except Exception:  # pragma: no cover - best effort
+                logger.warning("disconnect handler failed", exc_info=True)
+        if self.cfg.teleport.slots:
+            self.teleport(self.cfg.teleport.slots[0].slot)
+        for cb in list(self._on_death):
+            try:
+                cb()
+            except Exception:  # pragma: no cover - best effort
+                logger.warning("death handler failed", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # event hook registration
+    # ------------------------------------------------------------------
+    def add_on_disconnect(self, callback: Callable[[], None]) -> None:
+        """Register ``callback`` for disconnect events."""
+        self._on_disconnect.append(callback)
+
+    def add_on_death(self, callback: Callable[[], None]) -> None:
+        """Register ``callback`` for death events."""
+        self._on_death.append(callback)
+
+
+controller: GameController | None = None
+
+
+def create_controller(win: WindowCapture, cfg: AgentConfig | dict | None = None) -> GameController:
+    """Create and store a global :class:`GameController` instance."""
+    global controller
+    controller = GameController(win, cfg)
+    return controller
+
+
+__all__ = ["GameController", "controller", "create_controller"]

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -9,6 +9,7 @@ from recorder.window_capture import WindowCapture
 
 from . import AgentConfig, TeleportSlot
 from .strategy import AgentStrategy, load_strategy
+from .game_controller import create_controller
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ class WasdVisionAgent:
         self.channels = list(cfg.channels)
         self.teleport_slots = list(cfg.teleport.slots)
         self.win = WindowCapture(cfg.window.title_substr)
+        self.controller = create_controller(self.win, cfg)
         self.period = 1 / 15
         self.hd: AgentStrategy | None = None
 

--- a/agent/movement.py
+++ b/agent/movement.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from .wasd import KeyHold
+from .game_controller import GameController
 from .detector import Detection
 
 logger = logging.getLogger(__name__)
@@ -12,9 +13,16 @@ class MovementController:
     """Handle movement keys based on target position and obstacle steering."""
 
     def __init__(
-        self, keys: KeyHold, desired_w: float, deadzone: float, enabled: bool = True
+        self,
+        controller: GameController | KeyHold,
+        desired_w: float,
+        deadzone: float,
+        enabled: bool = True,
     ):
-        self.keys = keys
+        if isinstance(controller, GameController):
+            self.keys = controller.keys
+        else:
+            self.keys = controller
         self.desired_w = desired_w
         self.deadzone = deadzone
         self.enabled = enabled

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -11,6 +11,7 @@ import pyautogui
 from recorder.window_capture import WindowCapture
 
 from . import AgentConfig, get_config, teleport_config as tc
+from .game_controller import GameController
 
 try:  # pragma: no cover - prefer pydirectinput if available
     from pydirectinput import KeyHold  # type: ignore
@@ -46,6 +47,7 @@ class Teleporter:
         use_ocr: bool = False,
         dry: bool = False,
         cfg: AgentConfig | dict | None = None,
+        controller: GameController | None = None,
     ) -> None:
         if cfg is None:
             cfg = CFG
@@ -53,9 +55,15 @@ class Teleporter:
             cfg = AgentConfig(**cfg)
         self.cfg = cfg
         pyautogui.PAUSE = self.cfg.controls.mouse_pause
-        self.win = win
-        self.dry = dry
-        self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
+        self.controller = controller
+        if controller is not None:
+            self.win = controller.win
+            self.dry = dry or controller.dry
+            self.keys = controller.keys
+        else:
+            self.win = win
+            self.dry = dry
+            self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
 
         tp_cfg = self.cfg.teleport
         self.click_duration = tp_cfg.click_duration
@@ -66,6 +74,10 @@ class Teleporter:
     def _safe_click(self, x: int, y: int) -> None:
         if self.dry:
             return
+        controller = getattr(self, "controller", None)
+        if controller is not None:
+            controller.click(x, y, duration=self.click_duration)
+            return
         self.win.focus()
         if not self.win.is_foreground():
             return
@@ -75,8 +87,12 @@ class Teleporter:
     def open_panel(self, max_attempts: int = 3) -> bool:
         """Open teleport panel using ``Ctrl+X`` without any verification."""
 
-        self.win.focus()
-        if not self.win.is_foreground():
+        controller = getattr(self, "controller", None)
+        focus = controller.focus if controller else self.win.focus
+        is_foreground = controller.is_foreground if controller else self.win.is_foreground
+
+        focus()
+        if not is_foreground():
             logger.debug("Window is not in foreground before opening teleport panel")
             return False
 
@@ -85,7 +101,7 @@ class Teleporter:
             if not self.dry:
                 self.keys.hotkey(["ctrl", "x"], duration=0.05)
             time.sleep(self.open_panel_delay)
-            if not self.win.is_foreground():
+            if not is_foreground():
                 logger.debug(
                     "Window lost foreground after keypress on attempt %d", attempt + 1
                 )

--- a/tests/test_game_controller.py
+++ b/tests/test_game_controller.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import types
+
+# Ensure repository root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub optional dependencies
+pyautogui_stub = types.SimpleNamespace(moveTo=lambda *a, **k: None, click=lambda *a, **k: None, PAUSE=0)
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+# Stub recorder.window_capture to avoid heavy dependency
+recorder_pkg = types.ModuleType("recorder")
+recorder_pkg.__path__ = []
+wc_mod = types.ModuleType("recorder.window_capture")
+
+
+class WindowCapture:  # pragma: no cover - minimal stub
+    pass
+
+
+wc_mod.WindowCapture = WindowCapture
+recorder_pkg.window_capture = wc_mod
+sys.modules.setdefault("recorder", recorder_pkg)
+sys.modules.setdefault("recorder.window_capture", wc_mod)
+
+import agent.game_controller as gc
+
+# Replace KeyHold with a lightweight stub
+class DummyKeys:
+    def __init__(self, *a, **k):
+        self.released = False
+        self.hotkeys = []
+
+    def release_all(self):
+        self.released = True
+
+    def hotkey(self, keys, duration=0.05):
+        self.hotkeys.append((keys, duration))
+
+
+gc.KeyHold = DummyKeys  # type: ignore
+
+# Stub Teleporter to record calls
+class DummyTeleporter:
+    def __init__(self, win, cfg=None, controller=None):
+        self.calls = []
+
+    def teleport_slot(self, slot):
+        self.calls.append(slot)
+        return "ok"
+
+
+gc.Teleporter = DummyTeleporter  # type: ignore
+
+
+def make_controller():
+    win = types.SimpleNamespace(focus=lambda: None, is_foreground=lambda: True)
+    cfg = types.SimpleNamespace(
+        controls=types.SimpleNamespace(mouse_pause=0),
+        teleport=types.SimpleNamespace(slots=[types.SimpleNamespace(slot=2)], click_duration=0.05, open_panel_delay=0, row_click_delay=0, after_load_delay=0),
+        dry_run=False,
+    )
+    ctrl = gc.GameController(win, cfg)
+    ctrl._teleporter = DummyTeleporter(win, cfg, ctrl)
+    return ctrl
+
+
+def test_relog_triggers_hooks_and_teleport():
+    ctrl = make_controller()
+    events = []
+    ctrl.add_on_disconnect(lambda: events.append("disconnect"))
+    ctrl.add_on_death(lambda: events.append("death"))
+
+    ctrl.relog()
+
+    assert events == ["disconnect", "death"]
+    assert ctrl.teleporter.calls == [2]
+    assert ctrl.keys.released is True
+
+
+def test_teleport_method_delegates():
+    ctrl = make_controller()
+    ctrl.teleport(5)
+    assert ctrl.teleporter.calls == [5]


### PR DESCRIPTION
## Summary
- add `GameController` to centralise window focus and input with disconnect/death hooks
- refactor movement, teleport and inference agent to use the controller
- document controller API and cover reconnect/relog flows with tests

## Testing
- `pytest tests/test_game_controller.py tests/test_teleport_open_panel.py tests/test_teleport_close_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7b11d902c83308535c3c0bca519f2