### PR TITLE
Add message parser using Tesseract and spaCy for event detection

### DIFF
--- a/agent/message_parser.py
+++ b/agent/message_parser.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytesseract
+import spacy
+
+_nlp = None
+
+
+def _get_nlp() -> spacy.language.Language:
+    """Lazily load the spaCy model for Polish text."""
+    global _nlp
+    if _nlp is None:  # pragma: no cover - heavy initialisation
+        _nlp = spacy.load("pl_core_news_lg")
+    return _nlp
+
+
+def ocr_image(image) -> str:
+    """Extract text from ``image`` using Tesseract."""
+    return pytesseract.image_to_string(image, lang="pol")
+
+
+def classify_message(text: str) -> str | None:
+    """Return a high-level event name for ``text``.
+
+    Recognises simple game messages such as "no boss" and
+    "dungeon finished".  Returns ``None`` when the text does not match
+    any known pattern.
+    """
+
+    doc = _get_nlp()(text.lower())
+    lemmas = {t.lemma_ for t in doc}
+    if any(lemma in {"brak", "no"} for lemma in lemmas) and any(
+        "boss" in lemma for lemma in lemmas
+    ):
+        return "no boss"
+    if any(lemma.startswith("loch") or lemma == "dungeon" for lemma in lemmas) and any(
+        any(key in lemma for key in ("koniec", "ukoń", "finished", "skoń"))
+        for lemma in lemmas
+    ):
+        return "dungeon finished"
+    return None
+
+
+def parse_message(image) -> tuple[str, str | None]:
+    """OCR and classify a message contained in ``image``."""
+    text = ocr_image(image)
+    event = classify_message(text)
+    return text, event
+
+
+__all__ = ["parse_message", "ocr_image", "classify_message"]

--- a/agent/ocr.py
+++ b/agent/ocr.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import easyocr
 
+from .message_parser import parse_message as _parse_message
+
 
 class Ocr:
     """Wrapper around EasyOCR with a safer language initialisation.
@@ -37,3 +39,7 @@ class Ocr:
                 best = (x1, y1, x2, y2)
                 best_c = conf
         return best, best_c
+
+    def parse_message(self, frame_bgr):
+        """Return OCR text and classified event from ``frame_bgr``."""
+        return _parse_message(frame_bgr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ gymnasium==1.2.0
 stable-baselines3==2.7.0
 tensorboard>=2.0
 psutil==5.9.8
+pytesseract==0.3.13
+spacy==3.7.5

--- a/tests/test_message_parser.py
+++ b/tests/test_message_parser.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import types
+
+# Make repository root importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class DummyToken:
+    def __init__(self, lemma):
+        self.lemma_ = lemma
+
+
+class DummyNLP:
+    def __call__(self, text):
+        return [DummyToken(t) for t in text.split()]
+
+
+fake_spacy = types.SimpleNamespace(load=lambda name: DummyNLP())
+fake_pt = types.SimpleNamespace(image_to_string=lambda img, lang="pol": "")
+
+sys.modules["spacy"] = fake_spacy
+sys.modules["pytesseract"] = fake_pt
+
+import agent.message_parser as mp
+
+mp._nlp = DummyNLP()
+
+
+def _set_ocr(text: str) -> None:
+    mp.pytesseract.image_to_string = lambda img, lang="pol": text
+
+
+def test_classifies_no_boss():
+    _set_ocr("Brak bossa")
+    _, event = mp.parse_message(None)
+    assert event == "no boss"
+
+
+def test_classifies_dungeon_finished():
+    _set_ocr("Lochy ukończone")
+    _, event = mp.parse_message(None)
+    assert event == "dungeon finished"

--- a/tests/test_ocr_fallback.py
+++ b/tests/test_ocr_fallback.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import types
+
+# Make repository root importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class DummyReader:
+    def __init__(self, lang, gpu=False):
+        self.lang = lang
+        self.gpu = gpu
+
+    def readtext(self, frame):
+        return []
+
+
+def _reader(lang, gpu=False):
+    if lang == ["en"]:
+        return DummyReader(lang, gpu)
+    raise RuntimeError("missing lang")
+
+
+sys.modules["easyocr"] = types.SimpleNamespace(Reader=_reader)
+
+import agent.ocr as ocr_module
+
+
+def test_ocr_falls_back_to_english():
+    ocr = ocr_module.Ocr(["pl"])
+    assert ocr.reader.lang == ["en"]

--- a/tools/download_models.py
+++ b/tools/download_models.py
@@ -1,0 +1,10 @@
+import spacy.cli
+
+
+def main() -> None:
+    """Download required spaCy language models."""
+    spacy.cli.download("pl_core_news_lg")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Tesseract and spaCy dependencies and model download helper
- implement message_parser using pytesseract + spaCy with simple event classification
- integrate parser into OCR wrapper and provide tests for classification and fallback

## Testing
- `flake8 agent/message_parser.py agent/ocr.py tests/test_message_parser.py tests/test_ocr_fallback.py tools/download_models.py`
- `pytest tests/test_message_parser.py tests/test_ocr_fallback.py -q`
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b2f1b41c833093735d523f76bbc5