### PR TITLE
Add event parsing and strategy reactions

### DIFF
--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -12,6 +12,7 @@ from .channel import ChannelSwitcher
 from .detector import Detection, ObjectDetector
 from .interaction import click_bbox_center
 from .movement import MovementController
+from .message_parser import parse_message
 from .scanner import AreaScanner
 from .search import SearchManager
 from .strategy import AgentStrategy, register
@@ -116,6 +117,22 @@ class HuntDestroy(AgentStrategy):
         with self._grab_lock:
             fr = self.win.grab()
         frame = np.array(fr)[:, :, :3].copy()
+        _, event = parse_message(frame)
+        if event:
+            logger.info("Wykryto wiadomość: %s", event)
+            if event in {"no boss", "dungeon finished"}:
+                self.search.handle_no_target(True)
+                self._last_tgt = None
+                return
+            if event == "death":
+                self.keys.release_all()
+                self._last_tgt = None
+                return
+            if event == "inventory full":
+                self.keys.release_all()
+                # further handling (e.g. teleport) may be implemented later
+                self._last_tgt = None
+                return
         H, W = frame.shape[:2]
         dets = self.det.infer(frame)
         logger.debug("Wykryto %s obiektów", len(dets))

--- a/agent/message_parser.py
+++ b/agent/message_parser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytesseract
 import spacy
+from typing import Callable
 
 _nlp = None
 
@@ -12,6 +13,29 @@ def _get_nlp() -> spacy.language.Language:
     if _nlp is None:  # pragma: no cover - heavy initialisation
         _nlp = spacy.load("pl_core_news_lg")
     return _nlp
+
+
+def _contains_any(lemmas: set[str], *subs: str) -> bool:
+    """Return True when any ``subs`` substring is present in ``lemmas``."""
+    return any(any(sub in lemma for sub in subs) for lemma in lemmas)
+
+
+# Mapping of high level events to rule predicates operating on token lemmas.
+_RULES: dict[str, Callable[[set[str]], bool]] = {
+    "no boss": lambda lemmas: (
+        any(lemma in {"brak", "no"} for lemma in lemmas)
+        and _contains_any(lemmas, "boss")
+    ),
+    "dungeon finished": lambda lemmas: (
+        _contains_any(lemmas, "loch", "dungeon")
+        and _contains_any(lemmas, "koniec", "ukoń", "finished", "skoń")
+    ),
+    "death": lambda lemmas: _contains_any(lemmas, "zgin", "umar", "dead"),
+    "inventory full": lambda lemmas: (
+        _contains_any(lemmas, "ekwipunek", "inventory")
+        and _contains_any(lemmas, "pełn", "full")
+    ),
+}
 
 
 def ocr_image(image) -> str:
@@ -29,15 +53,12 @@ def classify_message(text: str) -> str | None:
 
     doc = _get_nlp()(text.lower())
     lemmas = {t.lemma_ for t in doc}
-    if any(lemma in {"brak", "no"} for lemma in lemmas) and any(
-        "boss" in lemma for lemma in lemmas
-    ):
-        return "no boss"
-    if any(lemma.startswith("loch") or lemma == "dungeon" for lemma in lemmas) and any(
-        any(key in lemma for key in ("koniec", "ukoń", "finished", "skoń"))
-        for lemma in lemmas
-    ):
-        return "dungeon finished"
+    for event, rule in _RULES.items():
+        try:
+            if rule(lemmas):
+                return event
+        except Exception:  # pragma: no cover - defensive
+            continue
     return None
 
 

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -44,6 +44,15 @@ easyocr_stub = types.ModuleType("easyocr")
 easyocr_stub.Reader = lambda *a, **k: None
 sys.modules.setdefault("easyocr", easyocr_stub)
 
+sys.modules.setdefault(
+    "spacy", types.SimpleNamespace(load=lambda name: None)
+)
+sys.modules.setdefault(
+    "pytesseract", types.SimpleNamespace(image_to_string=lambda img, lang="pol": "")
+)
+sys.modules.setdefault("mss", types.ModuleType("mss"))
+sys.modules.setdefault("pygetwindow", types.ModuleType("pygetwindow"))
+
 teleport_mod = types.ModuleType("agent.teleport")
 
 
@@ -78,6 +87,8 @@ sys.modules["agent.channel"] = channel_mod
 
 import agent.hunt_destroy as hd
 from agent.detector import Detection
+
+hd.parse_message = lambda frame: ("", None)
 
 
 class _StubKeyHold:

--- a/tests/test_message_parser.py
+++ b/tests/test_message_parser.py
@@ -41,3 +41,15 @@ def test_classifies_dungeon_finished():
     _set_ocr("Lochy ukończone")
     _, event = mp.parse_message(None)
     assert event == "dungeon finished"
+
+
+def test_classifies_death():
+    _set_ocr("Zginąłeś")
+    _, event = mp.parse_message(None)
+    assert event == "death"
+
+
+def test_classifies_inventory_full():
+    _set_ocr("Ekwipunek pełny")
+    _, event = mp.parse_message(None)
+    assert event == "inventory full"


### PR DESCRIPTION
## Summary
- expand `message_parser` with rules for player death and full inventory
- trigger `parse_message` in `HuntDestroy` strategy and react to recognised events
- cover new message types with unit tests and stub heavy dependencies

## Testing
- `pytest tests/test_message_parser.py tests/test_hunt_destroy.py -q`
- `pytest tests/test_cycle_sequence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7cde744b083308d70809e2f02d94c