### PR TITLE
Add game state management and reset hooks

### DIFF
--- a/agent/game_controller.py
+++ b/agent/game_controller.py
@@ -23,6 +23,7 @@ import pyautogui
 from recorder.window_capture import WindowCapture
 
 from . import AgentConfig, get_config
+from .game_state import GameState
 from .wasd import KeyHold
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
@@ -55,6 +56,7 @@ class GameController:
         self._on_disconnect: List[Callable[[], None]] = []
         self._on_death: List[Callable[[], None]] = []
         self._camera_pos: tuple[int, int] | None = None
+        self.state = GameState()
         if not self.dry:
             try:
                 self._camera_pos = pyautogui.position()
@@ -123,6 +125,13 @@ class GameController:
                 logger.warning("reset_camera failed: inactive window")
                 return
         pyautogui.moveTo(*self._camera_pos, duration=self.cfg.teleport.click_duration)
+
+    # ------------------------------------------------------------------
+    # state helpers
+    # ------------------------------------------------------------------
+    def reset_state(self) -> None:
+        """Restore :class:`GameState` to its default values."""
+        self.state.reset()
 
     # ------------------------------------------------------------------
     # fail‑safe helpers

--- a/agent/game_state.py
+++ b/agent/game_state.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GameState:
+    """Simple container for transient game state flags.
+
+    Tracks whether the player is mounted, equipment panel is open and whether
+    the minimap is visible.  Values are reset to the defaults via
+    :meth:`reset`.
+    """
+
+    mounted: bool = False
+    equipment_open: bool = False
+    minimap_open: bool = False
+
+    def reset(self) -> None:
+        """Return all flags to their default values."""
+        self.mounted = False
+        self.equipment_open = False
+        self.minimap_open = False

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -19,6 +19,7 @@ from .strategy import AgentStrategy, register
 from .targets import pick_target
 from .teleport import Teleporter
 from .wasd import KeyHold
+from .game_controller import controller
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +121,11 @@ class HuntDestroy(AgentStrategy):
         _, event = parse_message(frame)
         if event:
             logger.info("Wykryto wiadomość: %s", event)
+            if controller is not None:
+                try:
+                    controller.reset_state()
+                except Exception:  # pragma: no cover - best effort
+                    logger.warning("reset_state failed", exc_info=True)
             if event in {"no boss", "dungeon finished"}:
                 self.search.handle_no_target(True)
                 self._last_tgt = None

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import types
+
+# Ensure repository root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub optional dependencies
+class PyAutoStub:
+    PAUSE = 0
+
+    def __init__(self):
+        self.moves = []
+        self.presses = []
+        self._pos = (0, 0)
+
+    def moveTo(self, x, y, duration=0):
+        self.moves.append((x, y, duration))
+        self._pos = (x, y)
+
+    def click(self, *a, **k):
+        pass
+
+    def press(self, key):
+        self.presses.append(key)
+
+    def position(self):
+        return self._pos
+
+
+pyautogui_stub = PyAutoStub()
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+# Stub recorder.window_capture
+recorder_pkg = types.ModuleType("recorder")
+recorder_pkg.__path__ = []
+wc_mod = types.ModuleType("recorder.window_capture")
+
+
+class WindowCapture:  # pragma: no cover - minimal stub
+    pass
+
+
+wc_mod.WindowCapture = WindowCapture
+recorder_pkg.window_capture = wc_mod
+sys.modules.setdefault("recorder", recorder_pkg)
+sys.modules.setdefault("recorder.window_capture", wc_mod)
+
+import agent.game_controller as gc
+from agent.game_state import GameState
+
+
+class DummyWindow:
+    def __init__(self):
+        self.focus_calls = 0
+        self.foreground = True
+
+    def focus(self):
+        self.focus_calls += 1
+
+    def is_foreground(self):
+        return self.foreground
+
+
+def make_controller():
+    cfg = types.SimpleNamespace(
+        controls=types.SimpleNamespace(mouse_pause=0),
+        teleport=types.SimpleNamespace(slots=[], click_duration=0.05, open_panel_delay=0, row_click_delay=0, after_load_delay=0),
+        dry_run=True,
+    )
+    win = DummyWindow()
+
+    class DummyKeys:
+        def __init__(self, *a, **k):
+            pass
+
+        def release_all(self):
+            pass
+
+    class DummyTeleporter:
+        def __init__(self, *a, **k):
+            pass
+
+        def teleport_slot(self, slot):
+            return "ok"
+
+    gc.KeyHold = DummyKeys  # type: ignore
+    gc.Teleporter = DummyTeleporter  # type: ignore
+    return gc.GameController(win, cfg)
+
+
+def test_game_state_defaults_and_reset():
+    state = GameState()
+    assert state.mounted is False
+    assert state.equipment_open is False
+    assert state.minimap_open is False
+    state.mounted = state.equipment_open = state.minimap_open = True
+    state.reset()
+    assert state == GameState()
+
+
+def test_controller_reset_state():
+    ctrl = make_controller()
+    ctrl.state.mounted = True
+    ctrl.state.equipment_open = True
+    ctrl.state.minimap_open = True
+    ctrl.reset_state()
+    assert ctrl.state == GameState()


### PR DESCRIPTION
## Summary
- add `GameState` dataclass to track mount, equipment and minimap
- integrate `GameState` with `GameController` and expose `reset_state`
- invoke controller `reset_state` on unexpected events in `hunt_destroy`
- add tests for new state handling

## Testing
- `pytest tests/test_game_controller.py tests/test_hunt_destroy.py tests/test_game_state.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7cf36fea88330874138290f89f3a0