### PR TITLE
Add loot collection and inventory tracking

### DIFF
--- a/agent/game_state.py
+++ b/agent/game_state.py
@@ -15,9 +15,31 @@ class GameState:
     mounted: bool = False
     equipment_open: bool = False
     minimap_open: bool = False
+    inventory_slots: int = 0
+    inventory_occupied: int = 0
 
     def reset(self) -> None:
         """Return all flags to their default values."""
         self.mounted = False
         self.equipment_open = False
         self.minimap_open = False
+        self.inventory_occupied = 0
+
+    # ------------------------------------------------------------------
+    @property
+    def inventory_free(self) -> int:
+        """Number of free slots in the inventory."""
+
+        return max(0, self.inventory_slots - self.inventory_occupied)
+
+    def add_items(self, count: int = 1) -> None:
+        """Increase occupied inventory slots by ``count``."""
+
+        self.inventory_occupied = min(
+            self.inventory_slots, self.inventory_occupied + count
+        )
+
+    def remove_items(self, count: int = 1) -> None:
+        """Decrease occupied inventory slots by ``count``."""
+
+        self.inventory_occupied = max(0, self.inventory_occupied - count)

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -20,13 +20,15 @@ from .targets import pick_target
 from .teleport import Teleporter
 from .wasd import KeyHold
 from .game_controller import controller
+from .template_matcher import TemplateMatcher
+from .loot import LootCollector
 
 logger = logging.getLogger(__name__)
 
 
 @register("hunt_destroy")
 class HuntDestroy(AgentStrategy):
-    def __init__(self, cfg=None, window_capture=None):
+    def __init__(self, cfg=None, window_capture=None, on_inventory_full=None):
         self.cfg = None
         self.win = None
         self.det = None
@@ -34,6 +36,8 @@ class HuntDestroy(AgentStrategy):
         self.keys = None
         self.teleporter = None
         self.channel_switcher = None
+        self.matcher = None
+        self.loot = None
         self.desired_w = 0.0
         self.deadzone = 0.0
         self.priority = []
@@ -46,6 +50,7 @@ class HuntDestroy(AgentStrategy):
         self._grab_lock = threading.Lock()
         self.auto_press = None
         self._next_auto_press = 0.0
+        self.on_inventory_full = on_inventory_full
         if cfg is not None or window_capture is not None:
             self.setup(cfg, window_capture)
 
@@ -68,6 +73,14 @@ class HuntDestroy(AgentStrategy):
         self.keys = KeyHold(dry=dry, active_fn=getattr(self.win, "is_foreground", None))
         tdir = cfg.paths.templates_dir
         self.teleporter = Teleporter(self.win, tdir, use_ocr=True, dry=dry, cfg=cfg)
+        self.matcher = TemplateMatcher(tdir)
+        state = getattr(controller, "state", None)
+        self.loot = LootCollector(
+            detector=self.det,
+            matcher=self.matcher,
+            win=self.win,
+            state=state,
+        )
         ch_hotkeys = cfg.channel.hotkeys
         self.channel_switcher = ChannelSwitcher(
             self.win, tdir, dry=dry, keys=self.keys, hotkeys=ch_hotkeys
@@ -136,7 +149,23 @@ class HuntDestroy(AgentStrategy):
                 return
             if event == "inventory full":
                 self.keys.release_all()
-                # further handling (e.g. teleport) may be implemented later
+                if self.on_inventory_full:
+                    try:
+                        self.on_inventory_full()
+                    except Exception:  # pragma: no cover - defensive
+                        logger.warning("inventory callback failed", exc_info=True)
+                else:
+                    try:
+                        slot = (
+                            self.cfg.teleport.slots[0].slot
+                            if self.cfg.teleport.slots
+                            else 1
+                        )
+                        self.teleporter.teleport_slot(slot)
+                    except Exception:  # pragma: no cover - defensive
+                        logger.warning(
+                            "Teleport on inventory full failed", exc_info=True
+                        )
                 self._last_tgt = None
                 return
         H, W = frame.shape[:2]
@@ -146,12 +175,22 @@ class HuntDestroy(AgentStrategy):
         disappeared = self._prev_names - cur_names
         for name in disappeared:
             logger.debug("Obiekt %s zniknął", name)
+        if self._last_tgt and self._last_tgt.name in disappeared and self.loot:
+            try:
+                self.loot.collect(frame)
+            except Exception:  # pragma: no cover - best effort
+                logger.warning("loot collect failed", exc_info=True)
         self._prev_names = cur_names
 
         steer = self.avoid.steer(frame)
         tgt = pick_target(dets, (W, H), priority_order=self.priority)
         if tgt is None and self._last_tgt is not None:
             logger.debug("Cel %s zniknął", self._last_tgt.name)
+            if self.loot:
+                try:
+                    self.loot.collect(frame)
+                except Exception:  # pragma: no cover - best effort
+                    logger.warning("loot collect failed", exc_info=True)
         if tgt is None:
             logger.debug("Brak celu w zasięgu")
             if self.scanner:

--- a/agent/loot.py
+++ b/agent/loot.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from .detector import ObjectDetector
+from .template_matcher import TemplateMatcher
+from .interaction import click_bbox_center
+from .game_state import GameState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LootItem:
+    """Representation of a dropped item to collect."""
+
+    bbox: tuple[int, int, int, int]
+    score: float
+
+
+class LootCollector:
+    """Detect dropped items using YOLO or template matching and click them."""
+
+    def __init__(
+        self,
+        detector: ObjectDetector | None = None,
+        matcher: TemplateMatcher | None = None,
+        *,
+        item_classes: Sequence[str] | None = None,
+        template_name: str = "loot",
+        win=None,
+        state: GameState | None = None,
+    ) -> None:
+        self.detector = detector
+        self.matcher = matcher
+        self.item_classes = list(item_classes) if item_classes else ["loot"]
+        self.template_name = template_name
+        self.win = win
+        self.state = state
+
+    # ------------------------------------------------------------------
+    def _detect_yolo(self, frame: np.ndarray) -> list[LootItem]:
+        if not self.detector:
+            return []
+        items: list[LootItem] = []
+        dets = self.detector.infer(frame)
+        for d in dets:
+            if d.name in self.item_classes:
+                x1, y1, x2, y2 = map(int, d.bbox)
+                items.append(LootItem((x1, y1, x2, y2), d.conf))
+        return items
+
+    def _detect_template(self, frame: np.ndarray) -> list[LootItem]:
+        if not self.matcher:
+            return []
+        matches = self.matcher.find_all(frame, self.template_name)
+        items: list[LootItem] = []
+        for m in matches:
+            x, y, w, h = m.rect
+            items.append(LootItem((x, y, x + w, y + h), m.score))
+        return items
+
+    def detect(self, frame: np.ndarray) -> list[LootItem]:
+        """Return combined list of detected loot items."""
+
+        items = self._detect_yolo(frame)
+        items.extend(self._detect_template(frame))
+        return items
+
+    # ------------------------------------------------------------------
+    def collect(self, frame: np.ndarray) -> int:
+        """Click detected items and update ``GameState`` inventory counters."""
+
+        items = self.detect(frame)
+        if not items:
+            return 0
+        count = 0
+        region = getattr(self.win, "region", (0, 0, frame.shape[1], frame.shape[0]))
+        for item in items:
+            if self.state and self.state.inventory_free <= 0:
+                logger.debug("Inventory full; skipping remaining loot")
+                break
+            click_bbox_center(item.bbox, region, win=self.win)
+            if self.state:
+                self.state.add_items(1)
+            count += 1
+        return count
+
+
+__all__ = ["LootCollector", "LootItem"]

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -14,6 +14,7 @@ np = importlib.import_module("numpy")
 
 cv2_stub = types.ModuleType("cv2")
 cv2_stub.setNumThreads = lambda n: None
+cv2_stub.TM_CCOEFF_NORMED = 5
 sys.modules["cv2"] = cv2_stub
 
 ultra_stub = types.ModuleType("ultralytics")

--- a/tests/test_loot.py
+++ b/tests/test_loot.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import types
+
+import numpy as np
+
+# Ensure repository root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub pyautogui and cv2
+pyautogui_stub = types.SimpleNamespace(moveTo=lambda *a, **k: None, click=lambda *a, **k: None, PAUSE=0)
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+cv2_stub = types.ModuleType("cv2")
+cv2_stub.TM_CCOEFF_NORMED = 5
+sys.modules.setdefault("cv2", cv2_stub)
+
+from agent.game_state import GameState
+from agent.loot import LootCollector
+from agent.detector import Detection
+from agent.template_matcher import TemplateMatch
+
+
+class DummyWin:
+    region = (0, 0, 100, 100)
+
+    def focus(self):
+        pass
+
+    def is_foreground(self):
+        return True
+
+
+class DummyDetector:
+    def infer(self, frame):
+        return [Detection(name="loot", bbox=[10, 10, 20, 20], conf=0.9)]
+
+
+class DummyMatcher:
+    def find_all(self, frame, name, *a, **k):
+        return [TemplateMatch(rect=(30, 30, 5, 5), center=(32, 32), score=0.95)]
+
+
+def test_collect_updates_inventory_from_detector(monkeypatch):
+    clicks = []
+    monkeypatch.setattr("agent.loot.click_bbox_center", lambda bbox, region, win=None, rate_limit=True, button="left": (clicks.append(bbox), True)[1])
+    frame = np.zeros((40, 40, 3), dtype=np.uint8)
+    state = GameState(inventory_slots=5)
+    collector = LootCollector(detector=DummyDetector(), win=DummyWin(), state=state)
+    collected = collector.collect(frame)
+    assert collected == 1
+    assert state.inventory_occupied == 1
+    assert state.inventory_free == 4
+    assert clicks == [(10, 10, 20, 20)]
+
+
+def test_collect_uses_template_matcher(monkeypatch):
+    clicks = []
+    monkeypatch.setattr("agent.loot.click_bbox_center", lambda bbox, region, win=None, rate_limit=True, button="left": (clicks.append(bbox), True)[1])
+    frame = np.zeros((40, 40, 3), dtype=np.uint8)
+    state = GameState(inventory_slots=5)
+    collector = LootCollector(matcher=DummyMatcher(), win=DummyWin(), state=state)
+    collected = collector.collect(frame)
+    assert collected == 1
+    assert state.inventory_occupied == 1
+    assert state.inventory_free == 4
+    assert clicks == [(30, 30, 35, 35)]


### PR DESCRIPTION
## Summary
- add `LootCollector` for YOLO/template loot detection and clicking dropped items
- extend `GameState` with inventory slot tracking utilities
- integrate loot collection and inventory-full teleport into HuntDestroy

## Testing
- `pytest tests/test_game_state.py tests/test_hunt_destroy.py tests/test_loot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7d43933b88330a64d6462f4a0d66d