### PR TITLE
Add configurable buff manager with timers

### DIFF
--- a/agent/buff_manager.py
+++ b/agent/buff_manager.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+from typing import Callable, Iterable, List
+
+
+class KeyProvider:
+    """Protocol-like class for objects that can tap keys."""
+
+    def tap(self, key: str) -> None:  # pragma: no cover - interface definition
+        raise NotImplementedError
+
+
+@dataclass
+class Buff:
+    """Single buff configuration and timer."""
+
+    key: str
+    interval_sec: float
+    is_active: Callable[[], bool] | None = None
+    next_time: float = field(default_factory=lambda: time.monotonic())
+
+    def step(self, keys: KeyProvider) -> bool:
+        """Check and cast buff if needed.
+
+        Returns ``True`` if the key was pressed.
+        """
+
+        active = self.is_active() if self.is_active else False
+        if active:
+            return False
+        now = time.monotonic()
+        if now >= self.next_time:
+            keys.tap(self.key)
+            self.next_time = now + self.interval_sec
+            return True
+        return False
+
+
+class BuffManager:
+    """Manage multiple timed buffs."""
+
+    def __init__(self, keys: KeyProvider, buffs: Iterable[Buff] | None = None):
+        self.keys = keys
+        self.buffs: List[Buff] = list(buffs or [])
+
+    @classmethod
+    def from_config(cls, cfg, keys: KeyProvider) -> "BuffManager":
+        buffs = [Buff(b.key, b.interval_sec) for b in getattr(cfg, "buffs", [])]
+        return cls(keys, buffs)
+
+    def step(self) -> None:
+        for buff in self.buffs:
+            buff.step(self.keys)

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -22,6 +22,7 @@ from .wasd import KeyHold
 from .game_controller import controller
 from .template_matcher import TemplateMatcher
 from .loot import LootCollector
+from .buff_manager import BuffManager
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ class HuntDestroy(AgentStrategy):
         self._grab_lock = threading.Lock()
         self.auto_press = None
         self._next_auto_press = 0.0
+        self.buff_mgr: BuffManager | None = None
         self.on_inventory_full = on_inventory_full
         if cfg is not None or window_capture is not None:
             self.setup(cfg, window_capture)
@@ -118,6 +120,7 @@ class HuntDestroy(AgentStrategy):
         )
         self.auto_press = cfg.auto_press
         self._next_auto_press = time.monotonic() + cfg.auto_press.interval_sec
+        self.buff_mgr = BuffManager.from_config(cfg, self.keys)
         self._last_tgt = None
         self._prev_names = set()
 
@@ -128,6 +131,8 @@ class HuntDestroy(AgentStrategy):
             if now >= self._next_auto_press:
                 self.keys.tap(ap_cfg.key)
                 self._next_auto_press = now + ap_cfg.interval_sec
+        if self.buff_mgr:
+            self.buff_mgr.step()
         with self._grab_lock:
             fr = self.win.grab()
         frame = np.array(fr)[:, :, :3].copy()

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -36,6 +36,9 @@ auto_press:
   enabled: false
   key: "i"
   interval_sec: 60.0
+buffs:
+  - key: "f1"
+    interval_sec: 60.0
 priority: ["boss","metin","potwory"]
 teleport:
   slots:

--- a/config/models.py
+++ b/config/models.py
@@ -71,6 +71,13 @@ class AutoPressConfig(BaseModel):
     interval_sec: float = 60.0
 
 
+class BuffConfig(BaseModel):
+    """Configuration for a single timed buff."""
+
+    key: str
+    interval_sec: float
+
+
 class TeleportSlot(BaseModel):
     page: str
     slot: int
@@ -118,6 +125,7 @@ class AgentConfig(BaseModel):
     scan: ScanConfig = Field(default_factory=ScanConfig)
     cooldowns: CooldownsConfig = Field(default_factory=CooldownsConfig)
     auto_press: AutoPressConfig = Field(default_factory=AutoPressConfig)
+    buffs: List[BuffConfig] = Field(default_factory=list)
     priority: List[str] = Field(default_factory=lambda: ["boss", "metin", "potwory"])
     teleport: TeleportConfig = Field(default_factory=TeleportConfig)
     channels: List[int] = Field(default_factory=lambda: [1, 2, 3, 4, 5, 6, 7, 8])
@@ -137,6 +145,7 @@ __all__ = [
     "ScanConfig",
     "CooldownsConfig",
     "AutoPressConfig",
+    "BuffConfig",
     "TeleportConfig",
     "TeleportSlot",
     "ChannelConfig",

--- a/tests/test_buff_manager.py
+++ b/tests/test_buff_manager.py
@@ -1,0 +1,73 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import agent.buff_manager as bm
+
+
+class DummyKeys:
+    def __init__(self):
+        self.tapped = []
+
+    def tap(self, key: str) -> None:
+        self.tapped.append(key)
+
+
+def test_buff_manager_press(monkeypatch):
+    t = 0.0
+
+    def fake_time():
+        return t
+
+    monkeypatch.setattr(bm.time, "monotonic", fake_time)
+    keys = DummyKeys()
+    buff = bm.Buff("a", 1.0)
+    mgr = bm.BuffManager(keys, [buff])
+
+    mgr.step()
+    assert keys.tapped == ["a"]
+
+    mgr.step()
+    assert keys.tapped == ["a"]
+
+    t = 1.1
+    mgr.step()
+    assert keys.tapped == ["a", "a"]
+
+
+def test_buff_manager_respects_active(monkeypatch):
+    t = 0.0
+
+    def fake_time():
+        return t
+
+    monkeypatch.setattr(bm.time, "monotonic", fake_time)
+    keys = DummyKeys()
+    active = True
+
+    def is_active():
+        return active
+
+    buff = bm.Buff("b", 1.0, is_active=is_active)
+    mgr = bm.BuffManager(keys, [buff])
+
+    mgr.step()
+    assert keys.tapped == []
+
+    t = 0.5
+    mgr.step()
+    assert keys.tapped == []
+
+    active = False
+    t = 0.6
+    mgr.step()
+    assert keys.tapped == ["b"]
+
+    t = 1.5
+    mgr.step()
+    assert keys.tapped == ["b"]
+
+    t = 1.7
+    mgr.step()
+    assert keys.tapped == ["b", "b"]


### PR DESCRIPTION
## Summary
- implement `BuffManager` for timed key presses
- extend config with `buffs` list and integrate into HuntDestroy strategy
- test buff timing and active-check logic

## Testing
- `pytest tests/test_buff_manager.py -q`
- `pytest tests/test_agent_config.py -q`
- `pytest tests/test_hunt_destroy.py -q`
- `pytest -q` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d592c4b08330986975f8698edc6d