### PR TITLE
Add loguru logging with rotation

### DIFF
--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 
 import numpy as np
@@ -14,8 +13,7 @@ from agent.scanner import AreaScanner
 from agent.teleport import Teleporter
 from agent.wasd import KeyHold
 from recorder.window_capture import WindowCapture
-
-logger = logging.getLogger(__name__)
+from utils.logging_config import logger
 
 
 class CycleFarm:
@@ -108,19 +106,17 @@ class CycleFarm:
         try:
             self.agent.stop()
         except Exception as exc:  # pragma: no cover - best effort cleanup
-            logger.exception(
-                "Błąd podczas zatrzymywania strategii: %s", exc
-            )
+            logger.exception("Błąd podczas zatrzymywania strategii: {}", exc)
 
         try:
             self.keys.stop()
         except (RuntimeError, OSError) as exc:
-            logger.exception("Błąd podczas zatrzymywania klawiszy: %s", exc)
+            logger.exception("Błąd podczas zatrzymywania klawiszy: {}", exc)
 
         try:
             self.win.close()
         except (RuntimeError, OSError) as exc:
-            logger.exception("Błąd podczas zamykania okna: %s", exc)
+            logger.exception("Błąd podczas zamykania okna: {}", exc)
 
     # ---- detekcje ----
     def _any_target_seen(self) -> bool:
@@ -140,10 +136,10 @@ class CycleFarm:
         key = (ch, slot)
         last = self.cooldown.get(key, 0)
         if now - last < self.cooldown_min * 60:
-            logger.debug("Pomijam slot %s na kanale %s - cooldown", slot, ch)
+            logger.debug("Pomijam slot {} na kanale {} - cooldown", slot, ch)
             return
 
-        logger.info("Teleportuję na slot %s (ch%s)", slot, ch)
+        logger.info("Teleportuję na slot {} (ch{})", slot, ch)
         try:
             if hasattr(self.tp, "teleport_slot"):
                 await asyncio.to_thread(self.tp.teleport_slot, slot, page_label)
@@ -151,7 +147,7 @@ class CycleFarm:
                 await asyncio.to_thread(self.tp.teleport, slot, page_label)
         except Exception:
             logger.warning(
-                "Teleportacja na slot %s kanału %s nie powiodła się", slot, ch
+                "Teleportacja na slot {} kanału {} nie powiodła się", slot, ch
             )
             self.cooldown[key] = now
             return
@@ -161,11 +157,11 @@ class CycleFarm:
             await self.scanner.scan_async()
 
         if not self._any_target_seen() or self._stop:
-            logger.info("Brak celu na slocie %s kanału %s", slot, ch)
+            logger.info("Brak celu na slocie {} kanału {}", slot, ch)
             self.cooldown[key] = time.time()
             return
 
-        logger.debug("Rozpoczynam polowanie na slocie %s kanału %s", slot, ch)
+        logger.debug("Rozpoczynam polowanie na slocie {} kanału {}", slot, ch)
         t_end = time.time() + float(per_spot_sec)
         last_seen = time.time()
         while time.time() < t_end and not self._stop:
@@ -241,20 +237,20 @@ class CycleFarm:
                     ch, slot = item
                     steps.append((ch, slot))
         else:
-            steps = [
-                (ch, slot) for ch in range(ch_from, ch_to + 1) for slot in slots
-            ]
+            steps = [(ch, slot) for ch in range(ch_from, ch_to + 1) for slot in slots]
 
         current_ch = None
         for ch, slot in steps:
             if self._stop:
                 break
             if ch != current_ch:
-                logger.info("Przechodzę na kanał %s", ch)
+                logger.info("Przechodzę na kanał {}", ch)
                 try:
-                    await asyncio.to_thread(self.ch.switch, ch, post_wait=self.ch_settle)
+                    await asyncio.to_thread(
+                        self.ch.switch, ch, post_wait=self.ch_settle
+                    )
                 except Exception:
-                    logger.warning("Nie udało się zmienić kanału na %s", ch)
+                    logger.warning("Nie udało się zmienić kanału na {}", ch)
                 current_ch = ch
             if self._stop:
                 break

--- a/agent/game_controller.py
+++ b/agent/game_controller.py
@@ -16,7 +16,6 @@ camera orientation.
 """
 
 from typing import Callable, List, TYPE_CHECKING
-import logging
 
 import pyautogui
 
@@ -25,14 +24,13 @@ from recorder.window_capture import WindowCapture
 from . import AgentConfig, get_config
 from .game_state import GameState
 from .wasd import KeyHold
+from utils.logging_config import logger
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .teleport import Teleporter, TeleportResult
 else:  # pragma: no cover - runtime import inside property
     Teleporter = None  # type: ignore
     TeleportResult = None  # type: ignore
-
-logger = logging.getLogger(__name__)
 
 
 class GameController:
@@ -51,7 +49,9 @@ class GameController:
         self.win = win
         self.dry = cfg.dry_run
         pyautogui.PAUSE = cfg.controls.mouse_pause
-        self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
+        self.keys = KeyHold(
+            dry=self.dry, active_fn=getattr(self.win, "is_foreground", None)
+        )
         self._teleporter: Teleporter | None = None
         self._on_disconnect: List[Callable[[], None]] = []
         self._on_death: List[Callable[[], None]] = []
@@ -139,6 +139,7 @@ class GameController:
     @property
     def teleporter(self) -> "Teleporter":
         from .teleport import Teleporter  # local import to avoid cycle
+
         if self._teleporter is None:
             self._teleporter = Teleporter(self.win, cfg=self.cfg, controller=self)
         return self._teleporter
@@ -154,7 +155,7 @@ class GameController:
             try:
                 cb()
             except Exception:  # pragma: no cover - best effort
-                logger.warning("disconnect handler failed", exc_info=True)
+                logger.opt(exception=True).warning("disconnect handler failed")
         self.login()
         if self.cfg.teleport.slots:
             self.teleport(self.cfg.teleport.slots[0].slot)
@@ -162,7 +163,7 @@ class GameController:
             try:
                 cb()
             except Exception:  # pragma: no cover - best effort
-                logger.warning("death handler failed", exc_info=True)
+                logger.opt(exception=True).warning("death handler failed")
 
     # ------------------------------------------------------------------
     # event hook registration
@@ -179,7 +180,9 @@ class GameController:
 controller: GameController | None = None
 
 
-def create_controller(win: WindowCapture, cfg: AgentConfig | dict | None = None) -> GameController:
+def create_controller(
+    win: WindowCapture, cfg: AgentConfig | dict | None = None
+) -> GameController:
     """Create and store a global :class:`GameController` instance."""
     global controller
     controller = GameController(win, cfg)

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import threading
 import time
 
@@ -25,8 +24,7 @@ from .game_controller import controller
 from .template_matcher import TemplateMatcher
 from .loot import LootCollector
 from .buff_manager import BuffManager
-
-logger = logging.getLogger(__name__)
+from utils.logging_config import logger
 
 
 @register("hunt_destroy")
@@ -128,9 +126,7 @@ class HuntDestroy(AgentStrategy):
         self._last_tgt = None
         self._prev_names = set()
         fps = int(round(1 / self.period)) if self.period else 15
-        self.flow = FlowStuck(
-            cfg.stuck.window, fps=fps, min_mag=cfg.stuck.min_mag
-        )
+        self.flow = FlowStuck(cfg.stuck.window, fps=fps, min_mag=cfg.stuck.min_mag)
         self._recovery_action = cfg.stuck.recovery_action
 
     def step(self):
@@ -152,12 +148,12 @@ class HuntDestroy(AgentStrategy):
             return
         _, event = parse_message(frame)
         if event:
-            logger.info("Wykryto wiadomość: %s", event)
+            logger.info("Wykryto wiadomość: {}", event)
             if controller is not None:
                 try:
                     controller.reset_state()
                 except Exception:  # pragma: no cover - best effort
-                    logger.warning("reset_state failed", exc_info=True)
+                    logger.opt(exception=True).warning("reset_state failed")
             if event in {"no boss", "dungeon finished"}:
                 self.search.handle_no_target(True)
                 self._last_tgt = None
@@ -172,7 +168,7 @@ class HuntDestroy(AgentStrategy):
                     try:
                         self.on_inventory_full()
                     except Exception:  # pragma: no cover - defensive
-                        logger.warning("inventory callback failed", exc_info=True)
+                        logger.opt(exception=True).warning("inventory callback failed")
                 else:
                     try:
                         slot = (
@@ -182,34 +178,34 @@ class HuntDestroy(AgentStrategy):
                         )
                         self.teleporter.teleport_slot(slot)
                     except Exception:  # pragma: no cover - defensive
-                        logger.warning(
-                            "Teleport on inventory full failed", exc_info=True
+                        logger.opt(exception=True).warning(
+                            "Teleport on inventory full failed"
                         )
                 self._last_tgt = None
                 return
         H, W = frame.shape[:2]
         dets = self.det.infer(frame)
-        logger.debug("Wykryto %s obiektów", len(dets))
+        logger.debug("Wykryto {} obiektów", len(dets))
         cur_names = {d.name for d in dets}
         disappeared = self._prev_names - cur_names
         for name in disappeared:
-            logger.debug("Obiekt %s zniknął", name)
+            logger.debug("Obiekt {} zniknął", name)
         if self._last_tgt and self._last_tgt.name in disappeared and self.loot:
             try:
                 self.loot.collect(frame)
             except Exception:  # pragma: no cover - best effort
-                logger.warning("loot collect failed", exc_info=True)
+                logger.opt(exception=True).warning("loot collect failed")
         self._prev_names = cur_names
 
         steer = self.avoid.steer(frame)
         tgt = pick_target(dets, (W, H), priority_order=self.priority)
         if tgt is None and self._last_tgt is not None:
-            logger.debug("Cel %s zniknął", self._last_tgt.name)
+            logger.debug("Cel {} zniknął", self._last_tgt.name)
             if self.loot:
                 try:
                     self.loot.collect(frame)
                 except Exception:  # pragma: no cover - best effort
-                    logger.warning("loot collect failed", exc_info=True)
+                    logger.opt(exception=True).warning("loot collect failed")
         if tgt is None:
             logger.debug("Brak celu w zasięgu")
             if self.scanner:
@@ -259,14 +255,10 @@ class HuntDestroy(AgentStrategy):
 
         if self._recovery_action == "teleport":
             try:  # pragma: no cover - best effort
-                slot = (
-                    self.cfg.teleport.slots[0].slot
-                    if self.cfg.teleport.slots
-                    else 1
-                )
+                slot = self.cfg.teleport.slots[0].slot if self.cfg.teleport.slots else 1
                 self.teleporter.teleport_slot(slot)
             except Exception:
-                logger.warning("Teleport recovery failed", exc_info=True)
+                logger.opt(exception=True).warning("Teleport recovery failed")
             return
 
         # default action: brief rotation
@@ -288,7 +280,7 @@ class HuntDestroy(AgentStrategy):
             if getattr(self, "keys", None):
                 self.keys.stop()
         except Exception as exc:  # pragma: no cover - defensive
-            logger.exception("Błąd podczas zatrzymywania klawiszy: %s", exc)
+            logger.exception("Błąd podczas zatrzymywania klawiszy: {}", exc)
 
         # Teleporter has its own ``KeyHold`` instance
         try:
@@ -296,7 +288,7 @@ class HuntDestroy(AgentStrategy):
             if tp and getattr(tp, "keys", None):
                 tp.keys.stop()
         except Exception as exc:  # pragma: no cover - defensive
-            logger.exception("Błąd podczas zatrzymywania teleportu: %s", exc)
+            logger.exception("Błąd podczas zatrzymywania teleportu: {}", exc)
 
         # Cancel any ongoing area scan
         try:
@@ -304,11 +296,11 @@ class HuntDestroy(AgentStrategy):
             if scanner and hasattr(scanner, "cancel"):
                 scanner.cancel()
         except Exception as exc:  # pragma: no cover - defensive
-            logger.exception("Błąd podczas anulowania skanowania: %s", exc)
+            logger.exception("Błąd podczas anulowania skanowania: {}", exc)
 
         # Close window capture if available
         try:
             if getattr(self, "win", None) and hasattr(self.win, "close"):
                 self.win.close()
         except Exception as exc:  # pragma: no cover - defensive
-            logger.exception("Błąd podczas zamykania okna: %s", exc)
+            logger.exception("Błąd podczas zamykania okna: {}", exc)

--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import time
 
 import numpy as np
@@ -10,8 +9,7 @@ from recorder.window_capture import WindowCapture
 from . import AgentConfig, TeleportSlot
 from .strategy import AgentStrategy, load_strategy
 from .game_controller import create_controller
-
-logger = logging.getLogger(__name__)
+from utils.logging_config import logger
 
 
 class WasdVisionAgent:
@@ -60,5 +58,5 @@ class WasdVisionAgent:
                 try:
                     self.hd.stop()
                 except Exception as exc:  # pragma: no cover - best effort cleanup
-                    logger.warning("Failed to stop strategy: %s", exc)
+                    logger.warning("Failed to stop strategy: {}", exc)
             self.win.close()

--- a/agent/loot.py
+++ b/agent/loot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -10,8 +9,7 @@ from .detector import ObjectDetector
 from .template_matcher import TemplateMatcher
 from .interaction import click_bbox_center
 from .game_state import GameState
-
-logger = logging.getLogger(__name__)
+from utils.logging_config import logger
 
 
 @dataclass

--- a/agent/movement.py
+++ b/agent/movement.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import logging
-
 from .wasd import KeyHold
 from .game_controller import GameController
 from .detector import Detection
-
-logger = logging.getLogger(__name__)
+from utils.logging_config import logger
 
 
 class MovementController:

--- a/agent/search.py
+++ b/agent/search.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import logging
 import time
 
 from .channel import ChannelSwitcher
 from .teleport import Teleporter
-
-logger = logging.getLogger(__name__)
+from utils.logging_config import logger
 
 
 class SearchManager:
@@ -71,10 +69,10 @@ class SearchManager:
                         try:
                             self.channel_switcher.switch(ch)
                         except Exception:
-                            logger.warning("Nie udało si zmienić kanału na %s", ch)
+                            logger.warning("Nie udało si zmienić kanału na {}", ch)
                         self.channel_idx = (self.channel_idx + 1) % len(self.channels)
             else:
                 logger.debug("Lista slotów teleportu jest pusta")
         except Exception:
-            logger.warning("Teleportacja na slot %s nie powiodła się", slot)
+            logger.warning("Teleportacja na slot {} nie powiodła się", slot)
         self.last_target_time = now

--- a/agent/teleport.py
+++ b/agent/teleport.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Coordinate based teleporter."""
 
-import logging
 import time
 from enum import Enum
 
@@ -12,6 +11,7 @@ from recorder.window_capture import WindowCapture
 
 from . import AgentConfig, get_config, teleport_config as tc
 from .game_controller import GameController
+from utils.logging_config import logger
 
 try:  # pragma: no cover - prefer pydirectinput if available
     from pydirectinput import KeyHold  # type: ignore
@@ -19,8 +19,6 @@ except Exception:  # pragma: no cover - fallback to local implementation
     from .wasd import KeyHold
 
 CFG = get_config()
-
-logger = logging.getLogger(__name__)
 
 
 class TeleportResult(Enum):
@@ -63,7 +61,9 @@ class Teleporter:
         else:
             self.win = win
             self.dry = dry
-            self.keys = KeyHold(dry=self.dry, active_fn=getattr(self.win, "is_foreground", None))
+            self.keys = KeyHold(
+                dry=self.dry, active_fn=getattr(self.win, "is_foreground", None)
+            )
 
         tp_cfg = self.cfg.teleport
         self.click_duration = tp_cfg.click_duration
@@ -89,7 +89,9 @@ class Teleporter:
 
         controller = getattr(self, "controller", None)
         focus = controller.focus if controller else self.win.focus
-        is_foreground = controller.is_foreground if controller else self.win.is_foreground
+        is_foreground = (
+            controller.is_foreground if controller else self.win.is_foreground
+        )
 
         focus()
         if not is_foreground():
@@ -97,13 +99,13 @@ class Teleporter:
             return False
 
         for attempt in range(max_attempts):
-            logger.debug("Attempt %d to open teleport panel", attempt + 1)
+            logger.debug("Attempt {} to open teleport panel", attempt + 1)
             if not self.dry:
                 self.keys.hotkey(["ctrl", "x"], duration=0.05)
             time.sleep(self.open_panel_delay)
             if not is_foreground():
                 logger.debug(
-                    "Window lost foreground after keypress on attempt %d", attempt + 1
+                    "Window lost foreground after keypress on attempt {}", attempt + 1
                 )
                 return False
             return True
@@ -124,24 +126,24 @@ class Teleporter:
         Coordinates are loaded from ``config/teleport.yaml``.
         """
 
-        logger.debug("Teleporting to slot %s via coordinates", slot)
+        logger.debug("Teleporting to slot {} via coordinates", slot)
         if not self.open_panel():
             return TeleportResult.WINDOW_NOT_FOREGROUND
 
         cfg = tc.get_config()
         positions = cfg.positions
         if slot < 1 or slot > len(positions):
-            logger.info("Slot %s not configured", slot)
+            logger.info("Slot {} not configured", slot)
             return TeleportResult.TEMPLATE_NOT_FOUND
 
         x, y = positions[slot - 1]
-        logger.debug("Clicking teleport slot at (%d, %d)", x, y)
+        logger.debug("Clicking teleport slot at ({}, {})", x, y)
         self._safe_click(x, y)
         time.sleep(self.row_click_delay)
         if not self.dry:
             self.keys.tap("e")
         time.sleep(self.after_load_delay)
-        logger.info("Teleportation to slot %s successful", slot)
+        logger.info("Teleportation to slot {} successful", slot)
         return TeleportResult.OK
 
     def teleport(self, slot: int, page_label: str | None = None) -> TeleportResult:

--- a/agent/wasd.py
+++ b/agent/wasd.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import threading
 import time
 
@@ -12,7 +11,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - gracefully handle missing module
     pydirectinput = None
 
-logger = logging.getLogger(__name__)
+from utils.logging_config import logger
 
 # ``_user32`` is kept for backward compatibility but is unused when relying
 # solely on ``pydirectinput``.
@@ -31,17 +30,17 @@ def _send_scan(scan: int, keyup: bool = False, extended: bool = False) -> None:
 
     key = REVERSE_SCANCODES.get(scan)
     if not key:
-        logger.warning("Unknown scancode %r", scan)
+        logger.warning("Unknown scancode {!r}", scan)
         return
 
     func = pydirectinput.keyUp if keyup else pydirectinput.keyDown
     try:
         result = func(key, _pause=False)
         if result is False:
-            logger.warning("pydirectinput.%s returned False for %r", func.__name__, key)
+            logger.warning("pydirectinput.{} returned False for {}", func.__name__, key)
     except Exception:  # pragma: no cover - log but do not raise
-        logger.warning(
-            "pydirectinput.%s failed for %r", func.__name__, key, exc_info=True
+        logger.opt(exception=True).warning(
+            "pydirectinput.{} failed for {}", func.__name__, key
         )
 
 
@@ -241,7 +240,7 @@ class KeyHold:
         key = key.lower()
         with self.lock:
             if key not in self.down:
-                logger.debug("Naciśnięto klawisz %s", key)
+                logger.debug("Naciśnięto klawisz {}", key)
                 self._down(key)
                 self.down.add(key)
 
@@ -249,7 +248,7 @@ class KeyHold:
         key = key.lower()
         with self.lock:
             if key in self.down:
-                logger.debug("Zwolniono klawisz %s", key)
+                logger.debug("Zwolniono klawisz {}", key)
                 self._up(key)
                 self.down.remove(key)
 
@@ -280,7 +279,7 @@ class KeyHold:
     def release_all(self):
         with self.lock:
             if self.down:
-                logger.debug("Zwolniono wszystkie klawisze: %s", list(self.down))
+                logger.debug("Zwolniono wszystkie klawisze: {}", list(self.down))
             for k in list(self.down):
                 self._up(k)
             self.down.clear()

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -3,6 +3,7 @@ window:
 paths:
   templates_dir: "assets/templates"
   model: "runs/detect/train/weights/best.pt"
+  log_dir: "logs"
 controls:
   keys:
     forward: "w"
@@ -61,3 +62,7 @@ cycle:
   # sequence:
   #   - {ch: 1, slot: 1}
   #   - {ch: 2, slot: 3}
+
+logging:
+  level: INFO
+  retention: "7 days"

--- a/config/models.py
+++ b/config/models.py
@@ -15,6 +15,11 @@ class PathsConfig(BaseModel):
     log_dir: Optional[str] = None
 
 
+class LoggingConfig(BaseModel):
+    level: str = "INFO"
+    retention: str = "7 days"
+
+
 class KeyBindings(BaseModel):
     forward: str = "w"
     left: str = "a"
@@ -134,6 +139,7 @@ class AgentConfig(BaseModel):
     channel: ChannelConfig = Field(default_factory=ChannelConfig)
     cycle: CycleConfig = Field(default_factory=CycleConfig)
     dry_run: bool = False
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
 
 
 __all__ = [
@@ -152,4 +158,5 @@ __all__ = [
     "TeleportSlot",
     "ChannelConfig",
     "CycleConfig",
+    "LoggingConfig",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pyyaml = "6.0.2"
 gymnasium = "1.2.0"
 stable-baselines3 = "2.7.0"
 psutil = "5.9.8"
+loguru = "0.7.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ tensorboard>=2.0
 psutil==5.9.8
 pytesseract==0.3.13
 spacy==3.7.5
+loguru==0.7.2

--- a/tests/test_label_assistant_cli.py
+++ b/tests/test_label_assistant_cli.py
@@ -1,8 +1,8 @@
-import logging
 import sys
 import types
 
 import pytest
+from utils.logging_config import logger
 
 
 def test_skip_existing(monkeypatch, tmp_path, caplog):
@@ -37,9 +37,10 @@ def test_skip_existing(monkeypatch, tmp_path, caplog):
 
     import importlib
 
-    with caplog.at_level(logging.INFO):
-        la = importlib.import_module("tools.label_assistant")
-        la.main()
+    handler_id = logger.add(caplog.handler, format="{message}", level="INFO")
+    la = importlib.import_module("tools.label_assistant")
+    la.main()
+    logger.remove(handler_id)
 
     assert lbl.read_text() == "orig"
     assert "Skipping test.jpg" in caplog.text

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,19 @@
+from importlib import reload
+
+import utils.logging_config as logging_config
+
+
+def test_log_file_rotation(tmp_path):
+    reload(logging_config)
+    log_dir = tmp_path / "logs"
+    logger = logging_config.logger
+    logger.remove()
+    logger.add(
+        log_dir / "agent_{time}.log", rotation="1 KB", retention="1 day", level="INFO"
+    )
+    for _ in range(200):
+        logger.info("x" * 100)
+    logger.remove()
+    files = list(log_dir.glob("agent_*.log"))
+    assert len(files) >= 2
+    reload(logging_config)

--- a/tools/capture_template.py
+++ b/tools/capture_template.py
@@ -15,15 +15,13 @@ the Metin2 window, while ``--name`` determines the output filename.
 """
 
 import argparse
-import logging
 from pathlib import Path
 
 import cv2
 import numpy as np
 
 from recorder.window_capture import WindowCapture
-
-logging.basicConfig(level=logging.INFO)
+from utils.logging_config import logger
 
 
 def main() -> None:
@@ -55,10 +53,10 @@ def main() -> None:
         x, y, w, h = args.roi
         out_path = out / f"{args.name}.png"
         cv2.imwrite(str(out_path), frame[y : y + h, x : x + w])
-        logging.info("Saved template: %s (Zapisano szablon)", out_path)
+        logger.info("Saved template: {} (Zapisano szablon)", out_path)
     except Exception as exc:
-        logging.error(
-            "Template capture failed: %s (Błąd podczas przechwytywania szablonu)",
+        logger.error(
+            "Template capture failed: {} (Błąd podczas przechwytywania szablonu)",
             exc,
         )
 

--- a/tools/ds_health.py
+++ b/tools/ds_health.py
@@ -1,8 +1,7 @@
-import logging
 import statistics as st
 from pathlib import Path
 
-logging.basicConfig(level=logging.INFO)
+from utils.logging_config import logger
 
 root = Path("datasets/mt2")
 sizes: list[float] = []
@@ -14,6 +13,6 @@ for lbl in (root / "labels" / "train").glob("*.txt"):
         counts[int(c)] += 1
         sizes.append(float(w) * float(h))
 
-logging.info("bbox per class: %s", counts)
+logger.info("bbox per class: {}", counts)
 if sizes:
-    logging.info("median bbox area: %s", st.median(sizes))
+    logger.info("median bbox area: {}", st.median(sizes))

--- a/tools/extract_frames.py
+++ b/tools/extract_frames.py
@@ -10,12 +10,11 @@ process.
 from __future__ import annotations
 
 import argparse
-import logging
 from pathlib import Path
 
 import cv2
 
-logging.basicConfig(level=logging.INFO)
+from utils.logging_config import logger
 
 
 def main() -> None:
@@ -51,23 +50,21 @@ def main() -> None:
         )
     videos = sorted(rec_dir.glob("*.mp4"))
     if not videos:
-        logging.warning(
-            "Directory %s contains no .mp4 files (Katalog %s nie zawiera plików .mp4)",
+        logger.warning(
+            "Directory {} contains no .mp4 files (Katalog {} nie zawiera plików .mp4)",
             rec_dir,
             rec_dir,
         )
         return
 
-    logging.info(
-        "Found %d recordings (Znaleziono %d nagrań…)", len(videos), len(videos)
-    )
+    logger.info("Found {} recordings (Znaleziono {} nagrań…)", len(videos), len(videos))
     for vid in videos:
-        logging.info("Processing %s (Przetwarzam)", vid)
+        logger.info("Processing {} (Przetwarzam)", vid)
         try:
             cap = cv2.VideoCapture(str(vid))
             if not cap.isOpened():
-                logging.error(
-                    "Cannot open file %s, skipping (Nie można otworzyć pliku %s, pomijam)",
+                logger.error(
+                    "Cannot open file {}, skipping (Nie można otworzyć pliku {}, pomijam)",
                     vid,
                     vid,
                 )
@@ -84,16 +81,16 @@ def main() -> None:
                     saved += 1
                 i += 1
             cap.release()
-            logging.info("Saved %d frames (zapisano %d klatek)", saved, saved)
+            logger.info("Saved {} frames (zapisano {} klatek)", saved, saved)
         except Exception as exc:
-            logging.error(
-                "Error processing %s: %s (Błąd podczas przetwarzania %s: %s)",
+            logger.error(
+                "Error processing {}: {} (Błąd podczas przetwarzania {}: {})",
                 vid,
                 exc,
                 vid,
                 exc,
             )
-    logging.info("Done. (Gotowe.)")
+    logger.info("Done. (Gotowe.)")
 
 
 if __name__ == "__main__":

--- a/tools/label_assistant.py
+++ b/tools/label_assistant.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import argparse
-import logging
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
 import cv2
 import numpy as np
 from ultralytics import YOLO
+from utils.logging_config import logger
 
 # YOLO label (cx, cy, w, h) — wartości znormalizowane do [0, 1]
 Box = Tuple[float, float, float, float]
@@ -31,8 +31,8 @@ def _to_yolo_format(result, width: int, height: int) -> List[Box]:
     # konwersja do (cx, cy, w, h) w pikselach
     cx = (xyxy[:, 0] + xyxy[:, 2]) / 2.0
     cy = (xyxy[:, 1] + xyxy[:, 3]) / 2.0
-    w = (xyxy[:, 2] - xyxy[:, 0])
-    h = (xyxy[:, 3] - xyxy[:, 1])
+    w = xyxy[:, 2] - xyxy[:, 0]
+    h = xyxy[:, 3] - xyxy[:, 1]
 
     # normalizacja do [0,1]
     cx /= float(width)
@@ -40,7 +40,9 @@ def _to_yolo_format(result, width: int, height: int) -> List[Box]:
     w /= float(width)
     h /= float(height)
 
-    boxes.extend([(float(cx[i]), float(cy[i]), float(w[i]), float(h[i])) for i in range(len(cx))])
+    boxes.extend(
+        [(float(cx[i]), float(cy[i]), float(w[i]), float(h[i])) for i in range(len(cx))]
+    )
     return boxes
 
 
@@ -105,21 +107,21 @@ def main() -> None:
 
     images = list(_iter_images(img_dir))
     if not images:
-        logging.warning("Katalog %s nie zawiera obrazów.", img_dir)
+        logger.warning("Katalog {} nie zawiera obrazów.", img_dir)
         return
 
-    logging.info("Przetwarzam %d obrazów…", len(images))
+    logger.info("Przetwarzam {} obrazów…", len(images))
 
     for img_path in images:
         label_path = lbl_dir / f"{img_path.stem}.txt"
 
         if args.skip_existing and label_path.exists():
-            logging.info("Skipping %s", img_path.name)
+            logger.info("Skipping {}", img_path.name)
             continue
 
         img = cv2.imread(str(img_path))
         if img is None:
-            logging.error("Nie można odczytać %s, pomijam.", img_path)
+            logger.error("Nie można odczytać {}, pomijam.", img_path)
             continue
 
         result = model(img, conf=args.confidence, verbose=False)[0]
@@ -129,25 +131,21 @@ def main() -> None:
         if args.interactive:
             preview = result.plot()
             cv2.imshow("label-assistant: podgląd", preview)
-            logging.info("Naciśnij ENTER lub Y, aby zapisać; inny klawisz — pominiecie.")
+            logger.info("Naciśnij ENTER lub Y, aby zapisać; inny klawisz — pominiecie.")
             key = cv2.waitKey(0)
             cv2.destroyAllWindows()
             if key not in (ord("y"), ord("Y"), 13):
-                logging.info("Pominięto: %s", img_path.name)
+                logger.info("Pominięto: {}", img_path.name)
                 continue
 
         # Zapis etykiet
         with open(label_path, "w", encoding="utf-8") as f:
-            for (cx, cy, w, h) in boxes:
+            for cx, cy, w, h in boxes:
                 # Domyślnie klasa 0; w razie potrzeby rozbuduj o mapowanie klas.
                 f.write(f"0 {cx:.6f} {cy:.6f} {w:.6f} {h:.6f}\n")
 
-        logging.info("Zapisano %s (liczba bbox: %d)", label_path, len(boxes))
+        logger.info("Zapisano {} (liczba bbox: {})", label_path, len(boxes))
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s: %(message)s",
-    )
     main()

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from loguru import logger
+
+from agent import get_config
+
+cfg = get_config()
+log_dir = Path(cfg.paths.log_dir or "logs")
+log_dir.mkdir(parents=True, exist_ok=True)
+
+logger.remove()
+logger.add(sys.stderr, level=cfg.logging.level.upper())
+logger.add(
+    log_dir / "agent_{time}.log",
+    rotation="1 MB",
+    retention=cfg.logging.retention,
+    level=cfg.logging.level.upper(),
+)
+
+__all__ = ["logger"]


### PR DESCRIPTION
## Summary
- configure Loguru-based logger with file rotation and retention
- expose logging level and retention in configuration
- replace standard logging with shared logger across agents and tools
- verify log file rotation and adjust CLI test for new logger

## Testing
- `PYTHONPATH=. pytest tests/test_logging_config.py tests/test_label_assistant_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7d86e648c8330a8b35f50796bd2da