### PR TITLE
Add minimap navigation and player position tracking

### DIFF
--- a/agent/dungeon_polana.py
+++ b/agent/dungeon_polana.py
@@ -12,6 +12,7 @@ from .message_parser import parse_message
 from .strategy import AgentStrategy, register
 from .teleport import Teleporter
 from .wasd import KeyHold
+from . import minimap
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class DungeonPolana(AgentStrategy):
     * watch for in‑game error messages ("no boss", "dungeon finished", etc.).
     """
 
-    def __init__(self, cfg: AgentConfig | dict | None = None, window_capture: Any | None = None):
+    def __init__(self, cfg: AgentConfig | dict | None = None, window_capture: Any | None = None, use_navigation: bool = False):
         self.cfg: AgentConfig | None = None
         self.win = None
         self.det: ObjectDetector | None = None
@@ -40,6 +41,7 @@ class DungeonPolana(AgentStrategy):
         self.last_event: str | None = None
         if cfg is not None or window_capture is not None:
             self.setup(cfg, window_capture)
+        self.use_navigation = use_navigation
 
     # ------------------------------------------------------------------ setup
     def setup(self, cfg: AgentConfig | dict | None = None, window_capture: Any | None = None) -> None:
@@ -91,6 +93,13 @@ class DungeonPolana(AgentStrategy):
         boss = next((d for d in dets if d.name == "boss"), None)
         if boss:
             logger.debug("Boss detected")
+            if self.use_navigation:
+                cx = int((boss.bbox[0] + boss.bbox[2]) / 2)
+                cy = int((boss.bbox[1] + boss.bbox[3]) / 2)
+                try:
+                    minimap.navigate_to((cx, cy))
+                except Exception:  # pragma: no cover - best effort
+                    logger.warning("navigate_to failed", exc_info=True)
             self.last_boss_time = time.monotonic()
             return
 

--- a/agent/game_state.py
+++ b/agent/game_state.py
@@ -17,6 +17,7 @@ class GameState:
     minimap_open: bool = False
     inventory_slots: int = 0
     inventory_occupied: int = 0
+    player_pos: tuple[int, int] | None = None
 
     def reset(self) -> None:
         """Return all flags to their default values."""
@@ -24,6 +25,7 @@ class GameState:
         self.equipment_open = False
         self.minimap_open = False
         self.inventory_occupied = 0
+        self.player_pos = None
 
     # ------------------------------------------------------------------
     @property

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -12,6 +12,7 @@ from .channel import ChannelSwitcher
 from .detector import Detection, ObjectDetector
 from .interaction import click_bbox_center
 from .movement import MovementController
+from . import minimap
 from .message_parser import parse_message
 from .scanner import AreaScanner
 from .search import SearchManager
@@ -29,7 +30,7 @@ from utils.logging_config import logger
 
 @register("hunt_destroy")
 class HuntDestroy(AgentStrategy):
-    def __init__(self, cfg=None, window_capture=None, on_inventory_full=None):
+    def __init__(self, cfg=None, window_capture=None, on_inventory_full=None, use_navigation: bool = False):
         self.cfg = None
         self.win = None
         self.det = None
@@ -55,6 +56,7 @@ class HuntDestroy(AgentStrategy):
         self._next_auto_press = 0.0
         self.buff_mgr: BuffManager | None = None
         self.on_inventory_full = on_inventory_full
+        self.use_navigation = use_navigation
         if cfg is not None or window_capture is not None:
             self.setup(cfg, window_capture)
 
@@ -246,7 +248,15 @@ class HuntDestroy(AgentStrategy):
             logger.debug("Atakuję cel")
             click_bbox_center(tgt.bbox, (left, top, w, h), win=self.win)
         else:
-            self.movement.move(tgt, steer, (W, H))
+            if self.use_navigation:
+                cx = int((tgt.bbox[0] + tgt.bbox[2]) / 2)
+                cy = int((tgt.bbox[1] + tgt.bbox[3]) / 2)
+                try:
+                    minimap.navigate_to((cx, cy))
+                except Exception:  # pragma: no cover - best effort
+                    logger.opt(exception=True).warning("navigate_to failed")
+            else:
+                self.movement.move(tgt, steer, (W, H))
         self._last_tgt = tgt
 
     # ---- helpers ----

--- a/agent/minimap.py
+++ b/agent/minimap.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+import numpy as np
+
+from .game_controller import controller
+
+# Global reference to the latest minimap grid used for path finding
+_minimap: np.ndarray | None = None
+
+
+def extract_player_pos(frame: np.ndarray) -> Tuple[int, int] | None:
+    """Extract player position from a minimap ``frame``.
+
+    The frame is expected to contain integer values where ``0`` denotes a
+    walkable tile, ``1`` an obstacle and ``2`` marks the player's current
+    location.  The function updates ``GameState.player_pos`` on the global
+    controller if available and returns the detected position as ``(x, y)``.
+    """
+
+    global _minimap
+    _minimap = np.array(frame, copy=True)
+    loc = np.argwhere(_minimap == 2)
+    if loc.size == 0:
+        return None
+    y, x = map(int, loc[0])
+    pos = (x, y)
+    if controller is not None and getattr(controller, "state", None) is not None:
+        controller.state.player_pos = pos
+    return pos
+
+
+def navigate_to(target_xy: Tuple[int, int]) -> List[Tuple[int, int]]:
+    """Compute a path from current ``player_pos`` to ``target_xy``.
+
+    A simple A* search is performed on the most recent minimap grid.  The
+    function returns the list of coordinates from start to target (inclusive).
+    If a path is found the player's position in :class:`GameState` is updated
+    to the target coordinate.
+    """
+
+    if _minimap is None or controller is None or getattr(controller, "state", None) is None:
+        return []
+    start = controller.state.player_pos
+    if start is None:
+        return []
+    goal = tuple(map(int, target_xy))
+    height, width = _minimap.shape[:2]
+
+    def neighbors(node: Tuple[int, int]):
+        x, y = node
+        for dx, dy in ((1, 0), (0, 1), (-1, 0), (0, -1)):
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < width and 0 <= ny < height and _minimap[ny, nx] != 1:
+                yield (nx, ny)
+
+    def heuristic(a: Tuple[int, int], b: Tuple[int, int]) -> int:
+        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+    import heapq
+
+    open_set: list[tuple[int, int, Tuple[int, int]]] = []
+    heapq.heappush(open_set, (heuristic(start, goal), 0, start))
+    came_from: dict[Tuple[int, int], Tuple[int, int]] = {}
+    g_score: dict[Tuple[int, int], int] = {start: 0}
+
+    while open_set:
+        _, cost, current = heapq.heappop(open_set)
+        if current == goal:
+            path = [current]
+            while current in came_from:
+                current = came_from[current]
+                path.append(current)
+            path.reverse()
+            controller.state.player_pos = goal
+            return path
+        for nb in neighbors(current):
+            tentative = cost + 1
+            if tentative < g_score.get(nb, 1 << 30):
+                came_from[nb] = current
+                g_score[nb] = tentative
+                f = tentative + heuristic(nb, goal)
+                heapq.heappush(open_set, (f, tentative, nb))
+    return []
+
+
+__all__ = ["extract_player_pos", "navigate_to"]

--- a/tests/test_minimap_navigation.py
+++ b/tests/test_minimap_navigation.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import types
+import importlib.util
+
+import numpy as np
+
+# Repository root
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+# Create namespace package for 'agent'
+agent_pkg = types.ModuleType("agent")
+agent_pkg.__path__ = [os.path.join(repo_root, "agent")]
+sys.modules["agent"] = agent_pkg
+
+# Load GameState module
+spec = importlib.util.spec_from_file_location("agent.game_state", os.path.join(repo_root, "agent", "game_state.py"))
+game_state = importlib.util.module_from_spec(spec)
+sys.modules["agent.game_state"] = game_state
+spec.loader.exec_module(game_state)
+agent_pkg.game_state = game_state
+GameState = game_state.GameState
+
+# Provide stub game_controller
+gc_mod = types.ModuleType("agent.game_controller")
+gc_mod.controller = types.SimpleNamespace(state=GameState())
+sys.modules["agent.game_controller"] = gc_mod
+agent_pkg.game_controller = gc_mod
+
+gc = gc_mod
+
+# Load minimap module
+spec = importlib.util.spec_from_file_location("agent.minimap", os.path.join(repo_root, "agent", "minimap.py"))
+minimap = importlib.util.module_from_spec(spec)
+sys.modules["agent.minimap"] = minimap
+spec.loader.exec_module(minimap)
+agent_pkg.minimap = minimap
+
+
+def test_extract_and_navigate_updates_state():
+    grid = np.array([
+        [0, 0, 0],
+        [1, 1, 0],
+        [2, 0, 0],
+    ], dtype=np.uint8)
+
+    pos = minimap.extract_player_pos(grid)
+    assert pos == (0, 2)
+    assert gc.controller.state.player_pos == (0, 2)
+
+    path = minimap.navigate_to((2, 0))
+    assert path == [(0, 2), (1, 2), (2, 2), (2, 1), (2, 0)]
+    assert gc.controller.state.player_pos == (2, 0)


### PR DESCRIPTION
## Summary
- extend `GameState` with `player_pos`
- introduce `agent.minimap` with player extraction and A* navigation
- allow `HuntDestroy` and `DungeonPolana` to optionally use minimap navigation
- add unit test for minimap navigation and state update

## Testing
- `pytest tests/test_minimap_navigation.py -q`
- `pytest -q` *(fails: libGL.so.1 missing and syntax errors in config/models.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e3df374083308de79c641459aae3