### PR TITLE
Add multi-client manager and launcher mode

### DIFF
--- a/agent/multi_client.py
+++ b/agent/multi_client.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import time
+from typing import Iterable, Type
+
+from recorder.window_capture import WindowCapture
+from .strategy import AgentStrategy
+
+
+class ClientManager:
+    """Manage multiple client windows and run a strategy sequentially."""
+
+    def __init__(self, windows: Iterable[str | WindowCapture]):
+        self.clients: list[WindowCapture] = []
+        for w in windows:
+            if isinstance(w, str):
+                self.clients.append(WindowCapture(w))
+            else:
+                self.clients.append(w)
+
+    def run_cycle(
+        self,
+        strategy_cls: Type[AgentStrategy],
+        per_client_sec: float = 300.0,
+    ) -> None:
+        """Run ``strategy_cls`` on each client for ``per_client_sec`` seconds.
+
+        Each client is processed sequentially. The strategy is instantiated
+        with the window capture instance and ``step`` is called repeatedly
+        for the requested duration. After the time elapses the strategy is
+        stopped and the next client is processed.
+        """
+
+        for win in self.clients:
+            strategy = strategy_cls(window_capture=win)
+            start = time.monotonic()
+            while True:
+                strategy.step()
+                if time.monotonic() - start >= per_client_sec:
+                    break
+                time.sleep(0.1)
+            try:
+                strategy.stop()
+            except Exception:
+                pass

--- a/launcher.py
+++ b/launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 
 import keyboard
@@ -25,13 +26,30 @@ def _handle_teleport() -> None:
         _teleport_in_progress = False
 
 
-def main() -> None:
-    """Run environment checks then start the GUI application."""
+def main(argv: list[str] | None = None) -> None:
+    """Run environment checks then start the GUI application.
+
+    When ``--multi`` is provided, run the HuntDestroy strategy in
+    multi‑client mode instead of starting the GUI.
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--multi", type=int, default=0, help="number of clients")
+    args = parser.parse_args(argv)
 
     update_repository()
 
     if not check_requirements():
         sys.exit(1)
+
+    if args.multi:
+        from agent.multi_client import ClientManager
+        from agent.hunt_destroy import HuntDestroy
+
+        titles = [str(i + 1) for i in range(args.multi)]
+        mgr = ClientManager(titles)
+        mgr.run_cycle(HuntDestroy)
+        return
 
     keyboard.add_hotkey("ctrl+x", _handle_teleport)
 

--- a/tests/test_multi_client.py
+++ b/tests/test_multi_client.py
@@ -1,0 +1,45 @@
+import sys
+import types
+from pathlib import Path
+
+
+def test_client_rotation(monkeypatch):
+    # Ensure repository root is on sys.path
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+
+    # Stub optional dependencies used by window capture
+    monkeypatch.setitem(sys.modules, "mss", types.SimpleNamespace(mss=lambda: None))
+    monkeypatch.setitem(
+        sys.modules, "pygetwindow", types.SimpleNamespace(getAllWindows=lambda: [])
+    )
+
+    # Provide lightweight stub for the 'agent' package to avoid heavy imports
+    agent_pkg = types.ModuleType("agent")
+    agent_pkg.__path__ = [str(root / "agent")]
+    agent_pkg.AgentConfig = object
+    sys.modules.setdefault("agent", agent_pkg)
+
+    from agent.multi_client import ClientManager
+
+    steps = []
+
+    class DummyWindow:
+        def __init__(self, name):
+            self.name = name
+
+    class DummyStrategy:
+        def __init__(self, cfg=None, window_capture=None):
+            self.win = window_capture
+
+        def step(self):
+            steps.append(self.win.name)
+
+        def stop(self):
+            pass
+
+    windows = [DummyWindow("A"), DummyWindow("B"), DummyWindow("C")]
+    mgr = ClientManager(windows)
+    mgr.run_cycle(DummyStrategy, per_client_sec=0)
+
+    assert steps == ["A", "B", "C"]


### PR DESCRIPTION
## Summary
- add `ClientManager` to run strategies sequentially across multiple clients
- support `--multi` option in launcher to start HuntDestroy across N clients
- cover multi-client rotation with unit test

## Testing
- `pytest tests/test_multi_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e3e03cd08330805026c969e4dbdd