### PR TITLE
Add camera control helpers and tests

### DIFF
--- a/agent/game_controller.py
+++ b/agent/game_controller.py
@@ -17,6 +17,7 @@ camera orientation.
 
 from typing import Callable, List, TYPE_CHECKING
 
+import time
 import pyautogui
 
 from recorder.window_capture import WindowCapture
@@ -57,6 +58,8 @@ class GameController:
         self._on_disconnect: List[Callable[[], None]] = []
         self._on_death: List[Callable[[], None]] = []
         self._camera_pos: tuple[int, int] | None = None
+        self._cam_yaw = 0.0
+        self._cam_pitch = 0.0
         self.state = GameState()
         if not self.dry:
             try:
@@ -127,6 +130,72 @@ class GameController:
                 logger.warning("reset_camera failed: inactive window")
                 return
         pyautogui.moveTo(*self._camera_pos, duration=self.cfg.teleport.click_duration)
+
+    def move_camera_left(self, press_time: float) -> None:
+        """Rotate camera left for ``press_time`` seconds."""
+        self._cam_yaw -= press_time
+        if self.dry:
+            return
+        self.focus()
+        pyautogui.keyDown("left")
+        time.sleep(press_time)
+        pyautogui.keyUp("left")
+
+    def move_camera_right(self, press_time: float) -> None:
+        """Rotate camera right for ``press_time`` seconds."""
+        self._cam_yaw += press_time
+        if self.dry:
+            return
+        self.focus()
+        pyautogui.keyDown("right")
+        time.sleep(press_time)
+        pyautogui.keyUp("right")
+
+    def move_camera_up(self, press_time: float) -> None:
+        """Tilt camera up for ``press_time`` seconds."""
+        self._cam_pitch += press_time
+        if self.dry:
+            return
+        self.focus()
+        pyautogui.keyDown("up")
+        time.sleep(press_time)
+        pyautogui.keyUp("up")
+
+    def move_camera_down(self, press_time: float) -> None:
+        """Tilt camera down for ``press_time`` seconds."""
+        self._cam_pitch -= press_time
+        if self.dry:
+            return
+        self.focus()
+        pyautogui.keyDown("down")
+        time.sleep(press_time)
+        pyautogui.keyUp("down")
+
+    def calibrate_camera(self) -> None:
+        """Return camera to the last neutral orientation."""
+        if self.dry:
+            self._cam_yaw = 0.0
+            self._cam_pitch = 0.0
+            return
+        self.focus()
+        if self._cam_yaw > 0:
+            pyautogui.keyDown("left")
+            time.sleep(self._cam_yaw)
+            pyautogui.keyUp("left")
+        elif self._cam_yaw < 0:
+            pyautogui.keyDown("right")
+            time.sleep(-self._cam_yaw)
+            pyautogui.keyUp("right")
+        if self._cam_pitch > 0:
+            pyautogui.keyDown("down")
+            time.sleep(self._cam_pitch)
+            pyautogui.keyUp("down")
+        elif self._cam_pitch < 0:
+            pyautogui.keyDown("up")
+            time.sleep(-self._cam_pitch)
+            pyautogui.keyUp("up")
+        self._cam_yaw = 0.0
+        self._cam_pitch = 0.0
 
     # ------------------------------------------------------------------
     # state helpers

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -73,7 +73,7 @@ class HuntDestroy(AgentStrategy):
             cfg.detector.classes,
             cfg.detector.conf_thr,
             cfg.detector.iou_thr,
-            cv2_threads=cfg.detector.cv2_threads,
+            cv2_threads=getattr(cfg.detector, "cv2_threads", 0),
         )
         self.avoid = CollisionAvoid()
         dry = cfg.dry_run
@@ -88,7 +88,7 @@ class HuntDestroy(AgentStrategy):
             win=self.win,
             state=state,
         )
-        ch_hotkeys = cfg.channel.hotkeys
+        ch_hotkeys = getattr(cfg.channel, "hotkeys", {})
         self.channel_switcher = ChannelSwitcher(
             self.win, tdir, dry=dry, keys=self.keys, hotkeys=ch_hotkeys
         )
@@ -98,15 +98,15 @@ class HuntDestroy(AgentStrategy):
         scan_cfg = cfg.scan
         self.period = scan_cfg.period
         self.scanner = None
-        if scan_cfg.enabled:
+        if getattr(scan_cfg, "enabled", True):
             rot_key = cfg.controls.keys.rotate or cfg.controls.keys.left
             self.scanner = AreaScanner(
                 self.keys,
                 spin_key=rot_key,
-                sweep_ms=scan_cfg.sweep_ms,
-                sweeps=scan_cfg.sweeps,
-                idle_sec=scan_cfg.idle_sec,
-                pause=scan_cfg.pause,
+                sweep_ms=getattr(scan_cfg, "sweep_ms", 250),
+                sweeps=getattr(scan_cfg, "sweeps", 8),
+                idle_sec=getattr(scan_cfg, "idle_sec", 1.5),
+                pause=getattr(scan_cfg, "pause", 0.12),
             )
 
         tp_cfg = cfg.teleport
@@ -114,7 +114,7 @@ class HuntDestroy(AgentStrategy):
             self.teleporter,
             self.channel_switcher,
             [s.slot for s in tp_cfg.slots],
-            tp_cfg.page or tp_cfg.page_label,
+            getattr(tp_cfg, "page", None) or getattr(tp_cfg, "page_label", None),
             list(cfg.channels),
             tp_cfg.no_target_sec,
             tp_cfg.channel_every,
@@ -275,9 +275,12 @@ class HuntDestroy(AgentStrategy):
 
         # default action: brief rotation
         key = self.cfg.controls.keys.rotate or self.cfg.controls.keys.left
-        self.keys.press(key)
-        time.sleep(0.25)
-        self.keys.release(key)
+        if controller is not None:
+            controller.move_camera_right(0.25)
+        else:
+            self.keys.press(key)
+            time.sleep(0.25)
+            self.keys.release(key)
 
     def stop(self) -> None:
         """Release resources held by the strategy.

--- a/agent/scanner.py
+++ b/agent/scanner.py
@@ -6,6 +6,7 @@ import time
 from typing import Callable, Optional
 
 from .wasd import KeyHold
+from .game_controller import controller
 
 
 class AreaScanner:
@@ -50,11 +51,17 @@ class AreaScanner:
         for i in range(self.sweeps):
             if self._stop.is_set():
                 break
-            self.keys.press(self.spin_key)
-            if self._stop.wait(self.sweep_ms / 1000.0):
+            if controller is not None:
+                move = controller.move_camera_left
+                if self.spin_key.lower() not in {"q", "left"}:
+                    move = controller.move_camera_right
+                move(self.sweep_ms / 1000.0)
+            else:
+                self.keys.press(self.spin_key)
+                if self._stop.wait(self.sweep_ms / 1000.0):
+                    self.keys.release(self.spin_key)
+                    break
                 self.keys.release(self.spin_key)
-                break
-            self.keys.release(self.spin_key)
             self._progress = (i + 1) / float(self.sweeps)
             if self._progress_cb:
                 try:
@@ -66,6 +73,8 @@ class AreaScanner:
         else:
             # loop did not break -> full scan completed
             self._completed = True
+        if controller is not None:
+            controller.calibrate_camera()
 
     def scan(self, progress_cb: Optional[Callable[[float], None]] = None) -> None:
         """Start an asynchronous scan.

--- a/tests/test_game_controller_camera.py
+++ b/tests/test_game_controller_camera.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import types
+import importlib
+
+# Ensure repository root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_move_and_calibrate(monkeypatch):
+    class PyAutoStub:
+        PAUSE = 0
+
+        def __init__(self):
+            self.keydowns = []
+            self.keyups = []
+            self._pos = (0, 0)
+
+        def keyDown(self, key):
+            self.keydowns.append(key)
+
+        def keyUp(self, key):
+            self.keyups.append(key)
+
+        def position(self):
+            return self._pos
+
+        def moveTo(self, *a, **k):
+            pass
+
+        def click(self, *a, **k):
+            pass
+
+        def press(self, *a, **k):
+            pass
+
+    pyautogui_stub = PyAutoStub()
+    monkeypatch.setitem(sys.modules, "pyautogui", pyautogui_stub)
+
+    # Stub recorder.window_capture to avoid heavy dependency
+    recorder_pkg = types.ModuleType("recorder")
+    recorder_pkg.__path__ = []
+    wc_mod = types.ModuleType("recorder.window_capture")
+
+    class WindowCapture:  # pragma: no cover - minimal stub
+        pass
+
+    wc_mod.WindowCapture = WindowCapture
+    recorder_pkg.window_capture = wc_mod
+    monkeypatch.setitem(sys.modules, "recorder", recorder_pkg)
+    monkeypatch.setitem(sys.modules, "recorder.window_capture", wc_mod)
+
+    gc = importlib.import_module("agent.game_controller")
+    gc = importlib.reload(gc)
+
+    class DummyKeys:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(gc, "KeyHold", DummyKeys)
+
+    class DummyWindow:
+        def focus(self):
+            pass
+
+        def is_foreground(self):
+            return True
+
+    cfg = types.SimpleNamespace(
+        controls=types.SimpleNamespace(mouse_pause=0),
+        teleport=types.SimpleNamespace(
+            slots=[], click_duration=0.05, open_panel_delay=0, row_click_delay=0, after_load_delay=0
+        ),
+        dry_run=False,
+    )
+    ctrl = gc.GameController(DummyWindow(), cfg)
+    monkeypatch.setattr(gc.time, "sleep", lambda t: None)
+    ctrl.move_camera_right(0.5)
+    ctrl.move_camera_left(0.2)
+    assert pyautogui_stub.keydowns[:2] == ["right", "left"]
+    assert ctrl._cam_yaw == 0.3
+    ctrl.calibrate_camera()
+    assert pyautogui_stub.keydowns[-1] == "left"
+    assert ctrl._cam_yaw == 0.0


### PR DESCRIPTION
## Summary
- add camera movement helpers and calibration utilities to `GameController`
- switch scanning and stuck recovery to use controller camera methods
- add unit test for camera control

## Testing
- `pytest tests/test_game_controller.py tests/test_game_controller_camera.py tests/test_hunt_destroy.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7eaca18008330b23d356e48b8d51b