### PR TITLE
Add runtime config reload and GUI option

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -35,4 +35,12 @@ def get_config(path: str | Path = "config/agent.yaml") -> AgentConfig:
     return _cfg
 
 
-__all__ = ["get_config", "load_config", "AgentConfig", "TeleportSlot"]
+def reload_config(path: str | Path = "config/agent.yaml") -> AgentConfig:
+    """Reload configuration file and update the cached instance."""
+
+    global _cfg
+    _cfg = load_config(path)
+    return _cfg
+
+
+__all__ = ["get_config", "load_config", "reload_config", "AgentConfig", "TeleportSlot"]

--- a/agent/game_controller.py
+++ b/agent/game_controller.py
@@ -16,13 +16,14 @@ camera orientation.
 """
 
 from typing import Callable, List, TYPE_CHECKING
+from pathlib import Path
 
 import time
 import pyautogui
 
 from recorder.window_capture import WindowCapture
 
-from . import AgentConfig, get_config
+from . import AgentConfig, get_config, reload_config as _reload_cfg
 from utils.humanizer import random_pause
 from .game_state import GameState
 from .wasd import KeyHold
@@ -30,6 +31,7 @@ from utils.logging_config import logger
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .teleport import Teleporter, TeleportResult
+    from .strategy import AgentStrategy
 else:  # pragma: no cover - runtime import inside property
     Teleporter = None  # type: ignore
     TeleportResult = None  # type: ignore
@@ -61,11 +63,36 @@ class GameController:
         self._cam_yaw = 0.0
         self._cam_pitch = 0.0
         self.state = GameState()
+        self._strategies: List["AgentStrategy"] = []
         if not self.dry:
             try:
                 self._camera_pos = pyautogui.position()
             except Exception:  # pragma: no cover - best effort
                 self._camera_pos = None
+
+    # ------------------------------------------------------------------
+    # configuration helpers
+    # ------------------------------------------------------------------
+    def add_strategy(self, strategy: "AgentStrategy") -> None:
+        """Register an active strategy for configuration updates."""
+
+        self._strategies.append(strategy)
+
+    def reload_config(self, path: str | Path = "config/agent.yaml") -> AgentConfig:
+        """Reload configuration and update registered strategies."""
+
+        cfg = _reload_cfg(path)
+        self.cfg = cfg
+        self.dry = cfg.dry_run
+        self.keys.dry = self.dry
+        pyautogui.PAUSE = cfg.controls.mouse_pause
+        self._teleporter = None
+        for strat in list(self._strategies):
+            try:
+                strat.setup(cfg, getattr(strat, "win", self.win))
+            except Exception:  # pragma: no cover - defensive
+                logger.opt(exception=True).warning("strategy reload failed")
+        return cfg
 
     # ------------------------------------------------------------------
     # basic window helpers

--- a/agent/strategy.py
+++ b/agent/strategy.py
@@ -4,6 +4,7 @@ import importlib
 from typing import Callable, Dict, Protocol, Type
 
 from . import AgentConfig
+from .game_controller import controller as _controller
 
 
 class AgentStrategy(Protocol):
@@ -53,6 +54,11 @@ def load_strategy(cfg: AgentConfig | dict | None = None, window_capture=None) ->
         raise ValueError(f"Unknown strategy '{name}'")
     strategy = cls()
     strategy.setup(cfg, window_capture)
+    if _controller is not None:
+        try:
+            _controller.add_strategy(strategy)
+        except Exception:  # pragma: no cover - defensive
+            pass
     return strategy
 
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -15,6 +15,7 @@ from pynput import keyboard as pynput_keyboard
 from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtCore import QSettings
 
+import agent
 from agent.channel import ChannelSwitcher
 from agent.cycle import CycleFarm
 from agent.strategy import AgentStrategy, load_strategy
@@ -644,8 +645,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_load_cfg = QtWidgets.QPushButton(
             QtCore.QCoreApplication.translate("MainWindow", "Wczytaj konfigurację")
         )
+        self.btn_reload_cfg = QtWidgets.QPushButton(
+            QtCore.QCoreApplication.translate("MainWindow", "Reload config")
+        )
         actions_layout.addWidget(self.btn_save_cfg)
         actions_layout.addWidget(self.btn_load_cfg)
+        actions_layout.addWidget(self.btn_reload_cfg)
         left.addWidget(self.actions_box)
 
         # logs
@@ -712,6 +717,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_train.toggled.connect(self.train_yolo_api)
         self.btn_save_cfg.clicked.connect(self.save_config)
         self.btn_load_cfg.clicked.connect(self.load_config)
+        self.btn_reload_cfg.clicked.connect(self.reload_agent_config)
         self.scale_spin.valueChanged.connect(self.apply_scale)
         # hotkey F12
         self.start_hotkey_listener()
@@ -887,6 +893,9 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.btn_load_cfg.setText(
             QtCore.QCoreApplication.translate("MainWindow", "Wczytaj konfigurację")
+        )
+        self.btn_reload_cfg.setText(
+            QtCore.QCoreApplication.translate("MainWindow", "Reload config")
         )
 
         # logs and status
@@ -1132,6 +1141,20 @@ class MainWindow(QtWidgets.QMainWindow):
             self.seq_table.setItem(row, 0, QtWidgets.QTableWidgetItem(str(ch)))
             self.seq_table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(slot)))
         self.set_status("Wczytano konfigurację.")
+
+    def reload_agent_config(self) -> None:
+        """Reload agent configuration and notify running strategies."""
+
+        from agent.game_controller import controller as gc
+
+        try:
+            if gc is not None:
+                gc.reload_config()
+            else:
+                agent.reload_config()
+            self.set_status("Konfiguracja przeładowana.")
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            self.set_status(f"Błąd przeładowania: {exc}")
 
     # ---------- agent actions ----------
     def start_agent(self, checked: bool) -> None:

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -25,3 +25,22 @@ def test_load_config_reads_yaml(tmp_path, monkeypatch):
     path.write_text("dummy")
     cfg = agent.load_config(path)
     assert cfg.controls.mouse_pause == 0.1
+
+
+def test_reload_config(tmp_path, monkeypatch):
+    """reload_config should update the cached configuration instance."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("dummy")
+    cfg1 = agent.AgentConfig(controls={"mouse_pause": 0.1})
+    cfg2 = agent.AgentConfig(controls={"mouse_pause": 0.2})
+
+    monkeypatch.setattr(agent, "load_config", lambda p: cfg1)
+    agent._cfg = None
+    cfg = agent.get_config(path)
+    assert cfg.controls.mouse_pause == 0.1
+
+    monkeypatch.setattr(agent, "load_config", lambda p: cfg2)
+    new_cfg = agent.reload_config(path)
+    assert new_cfg.controls.mouse_pause == 0.2
+    assert agent.get_config(path).controls.mouse_pause == 0.2


### PR DESCRIPTION
## Summary
- add `reload_config` utility to agent package
- allow GameController and strategies to refresh configuration at runtime
- expose GUI button to reload config and propagate to running strategies
- test agent config reload without restarting process

## Testing
- `pytest tests/test_agent_config.py::test_reload_config -q`
- `pytest -q` *(fails: libGL.so.1 missing and other imports)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f0ab1d348330a81f1a371ec062d3