### PR TITLE
Add advanced settings tab with config binding

### DIFF
--- a/config/models.py
+++ b/config/models.py
@@ -80,6 +80,18 @@ class BuffConfig(BaseModel):
     interval_sec: float = 60.0
 
 
+class PotionsConfig(BaseModel):
+    hp_key: str = "f2"
+    hp_threshold: int = 40
+    mp_key: str = "f3"
+    mp_threshold: int = 30
+
+
+class MultiClientConfig(BaseModel):
+    count: int = 1
+    rotation: List[int] = []
+
+
 class TeleportSlot(BaseModel):
     page: str = "Strona I"
     slot: int = 1
@@ -121,11 +133,16 @@ class AgentConfig(BaseModel):
     cooldowns: CooldownsConfig = CooldownsConfig()
     auto_press: AutoPressConfig = AutoPressConfig()
     buffs: List[BuffConfig] = []
+    auto_loot: bool = False
+    inventory_manager: bool = False
+    potions: PotionsConfig = PotionsConfig()
     priority: List[str] = ["boss", "metin", "potwory"]
     teleport: TeleportConfig = TeleportConfig()
     channels: List[int] = [1, 2, 3, 4, 5, 6, 7, 8]
     channel: ChannelConfig = ChannelConfig()
     cycle: CycleConfig = CycleConfig()
+    pathfinding: bool = False
+    multi_client: MultiClientConfig = MultiClientConfig()
     dry_run: bool = False
     logging: LoggingConfig = LoggingConfig()
 
@@ -143,9 +160,11 @@ __all__ = [
     "CooldownsConfig",
     "AutoPressConfig",
     "BuffConfig",
+    "PotionsConfig",
     "TeleportConfig",
     "TeleportSlot",
     "ChannelConfig",
     "CycleConfig",
+    "MultiClientConfig",
     "LoggingConfig",
 ]

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 import logging
 import os
 import time
@@ -22,7 +23,8 @@ from agent.strategy import AgentStrategy, load_strategy
 from agent.wasd import KeyHold
 from gui.preview import PreviewWorker
 from gui.teleport_config_dialog import TeleportConfigDialog
-from gui.widgets import AgentPanel, ScanPanel, SettingsPanel
+from gui.widgets import AgentPanel, ScanPanel, SettingsPanel, AdvancedPanel
+import yaml
 from recorder.window_capture import WindowCapture
 
 logging.basicConfig(
@@ -34,6 +36,17 @@ logging.basicConfig(
     ],
 )
 logger = logging.getLogger(__name__)
+
+CONFIG_PATH = Path("config/agent.yaml")
+
+
+def save_agent_config(cfg) -> None:
+    """Persist ``cfg`` to the default YAML configuration file."""
+    try:
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            yaml.safe_dump(cfg.dict(), f, allow_unicode=True)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("saving config failed: %s", exc)
 
 
 # Configure Qt DPI behaviour for Windows to avoid crashes when changing DPI awareness.
@@ -424,7 +437,19 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # left pane with controls inside a scroll area so all sections remain accessible
         left_widget = QtWidgets.QWidget()
-        left = QtWidgets.QVBoxLayout(left_widget)
+        left_layout = QtWidgets.QVBoxLayout(left_widget)
+        self.tabs = QtWidgets.QTabWidget()
+        basic_tab = QtWidgets.QWidget()
+        left = QtWidgets.QVBoxLayout(basic_tab)
+        self.tabs.addTab(
+            basic_tab, QtCore.QCoreApplication.translate("MainWindow", "Główne")
+        )
+        self.advanced_panel = AdvancedPanel()
+        self.tabs.addTab(
+            self.advanced_panel,
+            QtCore.QCoreApplication.translate("MainWindow", "Zaawansowane"),
+        )
+        left_layout.addWidget(self.tabs)
         left_scroll = QtWidgets.QScrollArea()
         left_scroll.setWidget(left_widget)
         left_scroll.setWidgetResizable(True)
@@ -719,6 +744,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_load_cfg.clicked.connect(self.load_config)
         self.btn_reload_cfg.clicked.connect(self.reload_agent_config)
         self.scale_spin.valueChanged.connect(self.apply_scale)
+        self.cfg = agent.get_config()
+        self.advanced_panel.load_from_config(self.cfg)
+        self.advanced_panel.config_changed.connect(self.on_advanced_config_changed)
         # hotkey F12
         self.start_hotkey_listener()
 
@@ -779,6 +807,13 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.lang_combo.setItemText(
             1, QtCore.QCoreApplication.translate("MainWindow", "English")
+        )
+
+        self.tabs.setTabText(
+            0, QtCore.QCoreApplication.translate("MainWindow", "Główne")
+        )
+        self.tabs.setTabText(
+            1, QtCore.QCoreApplication.translate("MainWindow", "Zaawansowane")
         )
 
         # settings and agent sections handled by dedicated widgets
@@ -1141,6 +1176,15 @@ class MainWindow(QtWidgets.QMainWindow):
             self.seq_table.setItem(row, 0, QtWidgets.QTableWidgetItem(str(ch)))
             self.seq_table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(slot)))
         self.set_status("Wczytano konfigurację.")
+
+    def on_advanced_config_changed(self) -> None:
+        """Handle updates from the advanced settings tab."""
+        try:
+            self.advanced_panel.update_config(self.cfg)
+        except ValueError as exc:
+            QtWidgets.QMessageBox.warning(self, "Błąd", str(exc))
+            return
+        save_agent_config(self.cfg)
 
     def reload_agent_config(self) -> None:
         """Reload agent configuration and notify running strategies."""

--- a/gui/widgets/__init__.py
+++ b/gui/widgets/__init__.py
@@ -1,5 +1,6 @@
 from .agent_panel import AgentPanel
 from .scan_panel import ScanPanel
 from .settings_panel import SettingsPanel
+from .advanced_panel import AdvancedPanel
 
-__all__ = ["SettingsPanel", "AgentPanel", "ScanPanel"]
+__all__ = ["SettingsPanel", "AgentPanel", "ScanPanel", "AdvancedPanel"]

--- a/gui/widgets/advanced_panel.py
+++ b/gui/widgets/advanced_panel.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from PySide6 import QtCore, QtWidgets
+from config.models import BuffConfig
+
+
+class AdvancedPanel(QtWidgets.QWidget):
+    """Tab with advanced agent options."""
+
+    config_changed = QtCore.Signal()
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        # --- auto loot group ---
+        loot_box = QtWidgets.QGroupBox("Automatyczne zbieranie i ekwipunek")
+        loot_layout = QtWidgets.QVBoxLayout(loot_box)
+        self.auto_loot_chk = QtWidgets.QCheckBox("Auto loot")
+        self.inventory_manager_chk = QtWidgets.QCheckBox("Zarządzanie ekwipunkiem")
+        loot_layout.addWidget(self.auto_loot_chk)
+        loot_layout.addWidget(self.inventory_manager_chk)
+        layout.addWidget(loot_box)
+
+        # --- buffs and potions ---
+        buff_box = QtWidgets.QGroupBox("Buffy i mikstury")
+        buff_layout = QtWidgets.QFormLayout(buff_box)
+        self.hp_key_edit = QtWidgets.QLineEdit()
+        self.hp_thr_spin = QtWidgets.QSpinBox()
+        self.hp_thr_spin.setRange(0, 100)
+        self.mp_key_edit = QtWidgets.QLineEdit()
+        self.mp_thr_spin = QtWidgets.QSpinBox()
+        self.mp_thr_spin.setRange(0, 100)
+        buff_layout.addRow("Klawisz HP", self.hp_key_edit)
+        buff_layout.addRow("Próg HP", self.hp_thr_spin)
+        buff_layout.addRow("Klawisz MP", self.mp_key_edit)
+        buff_layout.addRow("Próg MP", self.mp_thr_spin)
+        self.buff_table = QtWidgets.QTableWidget(0, 2)
+        self.buff_table.setHorizontalHeaderLabels(["Klawisz", "Interwał [s]"])
+        buff_layout.addRow(self.buff_table)
+        buff_add_row = QtWidgets.QHBoxLayout()
+        self.buff_key_input = QtWidgets.QLineEdit()
+        self.buff_interval_input = QtWidgets.QSpinBox()
+        self.buff_interval_input.setRange(1, 3600)
+        self.buff_add_btn = QtWidgets.QPushButton("Dodaj buff")
+        self.buff_remove_btn = QtWidgets.QPushButton("Usuń buff")
+        buff_add_row.addWidget(self.buff_key_input)
+        buff_add_row.addWidget(self.buff_interval_input)
+        buff_add_row.addWidget(self.buff_add_btn)
+        buff_add_row.addWidget(self.buff_remove_btn)
+        buff_layout.addRow(buff_add_row)
+        layout.addWidget(buff_box)
+
+        # --- humanizer ---
+        hum_box = QtWidgets.QGroupBox("Anty-stuck & humanizacja")
+        hum_layout = QtWidgets.QFormLayout(hum_box)
+        self.stuck_window_spin = QtWidgets.QDoubleSpinBox()
+        self.stuck_window_spin.setRange(0.1, 5.0)
+        self.stuck_window_spin.setSingleStep(0.1)
+        self.pause_jitter_spin = QtWidgets.QDoubleSpinBox()
+        self.pause_jitter_spin.setRange(0.0, 1.0)
+        self.pause_jitter_spin.setSingleStep(0.01)
+        self.cursor_jitter_spin = QtWidgets.QDoubleSpinBox()
+        self.cursor_jitter_spin.setRange(0.0, 20.0)
+        self.cursor_jitter_spin.setSingleStep(0.1)
+        hum_layout.addRow("Okno stuck", self.stuck_window_spin)
+        hum_layout.addRow("Pause jitter", self.pause_jitter_spin)
+        hum_layout.addRow("Cursor jitter", self.cursor_jitter_spin)
+        layout.addWidget(hum_box)
+
+        # --- minimap navigation ---
+        nav_box = QtWidgets.QGroupBox("Nawigacja po minimapie")
+        nav_layout = QtWidgets.QHBoxLayout(nav_box)
+        self.pathfinding_chk = QtWidgets.QCheckBox("Pathfinding")
+        self.path_start_btn = QtWidgets.QPushButton("Start")
+        self.path_stop_btn = QtWidgets.QPushButton("Stop")
+        nav_layout.addWidget(self.pathfinding_chk)
+        nav_layout.addWidget(self.path_start_btn)
+        nav_layout.addWidget(self.path_stop_btn)
+        layout.addWidget(nav_box)
+
+        # --- multi client ---
+        mc_box = QtWidgets.QGroupBox("Multi-client")
+        mc_layout = QtWidgets.QFormLayout(mc_box)
+        self.clients_spin = QtWidgets.QSpinBox()
+        self.clients_spin.setRange(1, 8)
+        self.rotation_edit = QtWidgets.QLineEdit()
+        mc_layout.addRow("Klienci", self.clients_spin)
+        mc_layout.addRow("Rotacja", self.rotation_edit)
+        layout.addWidget(mc_box)
+
+        layout.addStretch()
+
+        # connect signals
+        for w in [
+            self.auto_loot_chk,
+            self.inventory_manager_chk,
+            self.hp_key_edit,
+            self.hp_thr_spin,
+            self.mp_key_edit,
+            self.mp_thr_spin,
+            self.stuck_window_spin,
+            self.pause_jitter_spin,
+            self.cursor_jitter_spin,
+            self.pathfinding_chk,
+            self.clients_spin,
+            self.rotation_edit,
+        ]:
+            if hasattr(w, "toggled"):
+                w.toggled.connect(self.config_changed)
+            elif hasattr(w, "editingFinished"):
+                w.editingFinished.connect(self.config_changed)
+            else:
+                w.valueChanged.connect(self.config_changed)  # type: ignore[arg-type]
+
+        self.buff_add_btn.clicked.connect(self.add_buff)
+        self.buff_remove_btn.clicked.connect(self.remove_buff)
+
+    # ---- buff management ----
+    def add_buff(self) -> None:
+        key = self.buff_key_input.text().strip()
+        if not key:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Błąd",
+                "Klawisz buffa nie może być pusty",
+            )
+            return
+        interval = self.buff_interval_input.value()
+        row = self.buff_table.rowCount()
+        self.buff_table.insertRow(row)
+        self.buff_table.setItem(row, 0, QtWidgets.QTableWidgetItem(key))
+        self.buff_table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(interval)))
+        self.buff_key_input.clear()
+        self.buff_interval_input.setValue(1)
+        self.config_changed.emit()
+
+    def remove_buff(self) -> None:
+        rows = {idx.row() for idx in self.buff_table.selectedIndexes()}
+        for row in sorted(rows, reverse=True):
+            self.buff_table.removeRow(row)
+        if rows:
+            self.config_changed.emit()
+
+    # ---- config binding ----
+    def load_from_config(self, cfg) -> None:
+        self.auto_loot_chk.setChecked(getattr(cfg, "auto_loot", False))
+        self.inventory_manager_chk.setChecked(getattr(cfg, "inventory_manager", False))
+        pot = getattr(cfg, "potions", None)
+        if pot:
+            self.hp_key_edit.setText(getattr(pot, "hp_key", ""))
+            self.hp_thr_spin.setValue(int(getattr(pot, "hp_threshold", 0)))
+            self.mp_key_edit.setText(getattr(pot, "mp_key", ""))
+            self.mp_thr_spin.setValue(int(getattr(pot, "mp_threshold", 0)))
+        self.buff_table.setRowCount(0)
+        for b in getattr(cfg, "buffs", []) or []:
+            row = self.buff_table.rowCount()
+            self.buff_table.insertRow(row)
+            self.buff_table.setItem(row, 0, QtWidgets.QTableWidgetItem(b.key))
+            self.buff_table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(b.interval_sec)))
+        self.stuck_window_spin.setValue(getattr(getattr(cfg, "stuck", None), "window", 0.8))
+        self.pause_jitter_spin.setValue(getattr(getattr(cfg, "humanizer", None), "pause_jitter", 0.05))
+        self.cursor_jitter_spin.setValue(getattr(getattr(cfg, "humanizer", None), "cursor_jitter", 2.0))
+        self.pathfinding_chk.setChecked(getattr(cfg, "pathfinding", False))
+        mc = getattr(cfg, "multi_client", None)
+        if mc:
+            self.clients_spin.setValue(getattr(mc, "count", 1))
+            self.rotation_edit.setText(
+                ",".join(str(i) for i in getattr(mc, "rotation", []))
+            )
+
+    def update_config(self, cfg) -> None:
+        cfg.auto_loot = self.auto_loot_chk.isChecked()
+        cfg.inventory_manager = self.inventory_manager_chk.isChecked()
+        if not hasattr(cfg, "potions"):
+            from config.models import PotionsConfig
+
+            cfg.potions = PotionsConfig()
+        cfg.potions.hp_key = self.hp_key_edit.text().strip()
+        cfg.potions.hp_threshold = int(self.hp_thr_spin.value())
+        cfg.potions.mp_key = self.mp_key_edit.text().strip()
+        cfg.potions.mp_threshold = int(self.mp_thr_spin.value())
+        buffs = []
+        for row in range(self.buff_table.rowCount()):
+            key_item = self.buff_table.item(row, 0)
+            interval_item = self.buff_table.item(row, 1)
+            if key_item is None or not key_item.text().strip():
+                raise ValueError("Klawisz buffa nie może być pusty")
+            buffs.append(
+                BuffConfig(key=key_item.text().strip(), interval_sec=float(interval_item.text()))
+            )
+        cfg.buffs = buffs
+        cfg.stuck.window = float(self.stuck_window_spin.value())
+        cfg.humanizer.pause_jitter = float(self.pause_jitter_spin.value())
+        cfg.humanizer.cursor_jitter = float(self.cursor_jitter_spin.value())
+        cfg.pathfinding = self.pathfinding_chk.isChecked()
+        if not hasattr(cfg, "multi_client"):
+            from config.models import MultiClientConfig
+
+            cfg.multi_client = MultiClientConfig()
+        cfg.multi_client.count = int(self.clients_spin.value())
+        rot_text = self.rotation_edit.text().strip()
+        cfg.multi_client.rotation = [int(x) for x in rot_text.split(",") if x.strip().isdigit()]
+        self.config_changed.emit()

--- a/tests/test_gui_config.py
+++ b/tests/test_gui_config.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+import os
+
+from PySide6 import QtWidgets
+
+# ensure repo root on path
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+os.environ.setdefault("DISPLAY", ":0")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+import types
+sys.modules.setdefault("pyautogui", types.SimpleNamespace(FAILSAFE=False))
+class DummyListener:
+    def __init__(self, *a, **k):
+        self.daemon = False
+
+    def start(self):
+        return None
+
+keyboard_stub = types.SimpleNamespace(Listener=DummyListener, Key=types.SimpleNamespace(f12="f12"))
+sys.modules.setdefault("pynput", types.SimpleNamespace(keyboard=keyboard_stub))
+sys.modules.setdefault("mss", types.SimpleNamespace(mss=lambda: None))
+sys.modules.setdefault("pygetwindow", types.SimpleNamespace(getAllWindows=lambda: []))
+
+import agent
+from gui import main_window
+
+
+def make_app():
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def test_auto_loot_binding(monkeypatch):
+    make_app()
+    cfg = agent.AgentConfig()
+    cfg.auto_loot = False
+
+    monkeypatch.setattr(agent, "get_config", lambda: cfg)
+    saved: dict = {}
+    monkeypatch.setattr(main_window, "save_agent_config", lambda c: saved.update(c.dict()))
+
+    mw = main_window.MainWindow()
+    assert mw.advanced_panel.auto_loot_chk.isChecked() is False
+    mw.advanced_panel.auto_loot_chk.setChecked(True)
+    assert cfg.auto_loot is True
+    assert saved["auto_loot"] is True
+
+
+def test_buff_validation(monkeypatch):
+    make_app()
+    cfg = agent.AgentConfig()
+    monkeypatch.setattr(agent, "get_config", lambda: cfg)
+    monkeypatch.setattr(main_window, "save_agent_config", lambda c: None)
+    warned = {}
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: warned.setdefault("called", True))
+    mw = main_window.MainWindow()
+    rows = mw.advanced_panel.buff_table.rowCount()
+    mw.advanced_panel.buff_key_input.setText("")
+    mw.advanced_panel.add_buff()
+    assert mw.advanced_panel.buff_table.rowCount() == rows
+    assert warned.get("called")


### PR DESCRIPTION
## Summary
- add Advanced settings tab for auto loot, buffs, humanizer, minimap navigation and multi-client options
- persist UI changes to `agent.yaml` and synchronize with `AgentConfig`
- cover new binding and validation paths in GUI tests

## Testing
- `pytest tests/test_gui_config.py tests/test_agent_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7f3f03ff483308f1f362651cb5949