### PR TITLE
Add configurable channel hotkeys

### DIFF
--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -66,7 +66,15 @@ channels: [1,2,3,4,5,6,7,8]
 channel:
   settle_sec: 5.0
   timeout_per_ch: 5.0
-  hotkeys: {}
+  hotkeys:
+    1: numpad1
+    2: numpad2
+    3: numpad3
+    4: numpad4
+    5: numpad5
+    6: numpad6
+    7: numpad7
+    8: numpad8
 
 cycle:
   ch_from: 1

--- a/config/models.py
+++ b/config/models.py
@@ -110,6 +110,7 @@ class TeleportConfig(BaseModel):
 class ChannelConfig(BaseModel):
     settle_sec: float = 5.0
     timeout_per_ch: float = 5.0
+    hotkeys: Dict[int, str] = {i: f"numpad{i}" for i in range(1, 9)}
 
 
 class CycleConfig(BaseModel):

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -21,6 +21,7 @@ from agent.channel import ChannelSwitcher
 from agent.cycle import CycleFarm
 from agent.strategy import AgentStrategy, load_strategy
 from agent.wasd import KeyHold
+from config.models import ChannelConfig
 from gui.preview import PreviewWorker
 from gui.teleport_config_dialog import TeleportConfigDialog
 from gui.widgets import AgentPanel, ScanPanel, SettingsPanel, AdvancedPanel
@@ -1072,9 +1073,14 @@ class MainWindow(QtWidgets.QMainWindow):
         cfg.update(self.settings_panel.get_config())
         cfg.update(self.agent_panel.get_config())
         cfg.update(self.scan_panel.get_config(self.rotate_chk.isChecked()))
+        default_hotkeys = ChannelConfig().hotkeys
         hotkeys = {
-            i: self.ch_key_edits[i].text().strip() or f"numpad{i}" for i in range(1, 9)
+            i: self.ch_key_edits[i].text().strip() or default_hotkeys[i]
+            for i in range(1, 9)
         }
+        ch_cfg = ChannelConfig(
+            settle_sec=5.0, timeout_per_ch=2.5, hotkeys=hotkeys
+        )
         cfg.update(
             {
                 "stuck": {
@@ -1083,11 +1089,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     "recovery_action": "rotate",
                 },
                 "cooldowns": {"slot_min": int(self.cooldown_spin.value())},
-                "channel": {
-                    "settle_sec": 5.0,
-                    "timeout_per_ch": 2.5,
-                    "hotkeys": hotkeys,
-                },
+                "channel": ch_cfg.dict(),
                 "ui": {"scale": float(self.scale_spin.value())},
             }
         )
@@ -1162,8 +1164,9 @@ class MainWindow(QtWidgets.QMainWindow):
         for name in cfg.get("priority", []):
             self.prio_list.addItem(QtWidgets.QListWidgetItem(name))
         ch_hot = cfg.get("channel", {}).get("hotkeys", {})
+        default_hotkeys = ChannelConfig().hotkeys
         for i in range(1, 9):
-            key = ch_hot.get(str(i)) or ch_hot.get(i) or f"numpad{i}"
+            key = ch_hot.get(str(i)) or ch_hot.get(i) or default_hotkeys[i]
             self.ch_key_edits[i].setText(key)
 
         seq = cfg.get("cycle", {}).get("sequence", [])

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -1,0 +1,100 @@
+import os
+import sys
+import types
+from dataclasses import dataclass
+from typing import Tuple
+
+import pytest
+
+# Ensure repository root on path and stub optional dependencies
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda f: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
+# Stub pyautogui to avoid real mouse interaction
+pyautogui_stub = types.SimpleNamespace(moveTo=lambda *a, **k: None, click=lambda *a, **k: None, PAUSE=0)
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+# Stub recorder.window_capture so ChannelSwitcher can be imported without dependencies
+recorder_pkg = types.ModuleType("recorder")
+recorder_pkg.__path__ = []
+wc_mod = types.ModuleType("recorder.window_capture")
+
+
+class WindowCapture:
+    def __init__(self, *a, **k):
+        self.region = (0, 0, 300, 300)
+
+    def grab(self):
+        import numpy as np
+
+        return np.zeros((300, 300, 4), dtype=np.uint8)
+
+    def focus(self):
+        pass
+
+    def is_foreground(self):
+        return True
+
+
+wc_mod.WindowCapture = WindowCapture
+recorder_pkg.window_capture = wc_mod
+sys.modules.setdefault("recorder", recorder_pkg)
+sys.modules.setdefault("recorder.window_capture", wc_mod)
+
+# Provide a minimal TemplateMatcher stub used during import
+_tm_mod = types.ModuleType("agent.template_matcher")
+
+
+class _TM:
+    def __init__(self, *a, **k):
+        pass
+
+    def find(self, *a, **k):
+        return None
+
+
+@dataclass
+class _Match:
+    rect: Tuple[int, int, int, int]
+    center: Tuple[int, int]
+    score: float
+
+
+_tm_mod.TemplateMatcher = _TM
+_tm_mod.TemplateMatch = _Match
+sys.modules.setdefault("agent.template_matcher", _tm_mod)
+
+import agent.channel as channel
+from config.models import AgentConfig, ChannelConfig, PathsConfig, WindowConfig
+
+
+class KH:
+    def __init__(self):
+        self.calls: list[tuple[list[str], float]] = []
+
+    def hotkey(self, keys, duration=0.05):
+        self.calls.append((keys, duration))
+
+
+def _setup_templates(tmp_path):
+    for i in range(1, 9):
+        (tmp_path / f"ch{i}.png").touch()
+
+
+def test_switch_uses_configured_hotkeys(tmp_path):
+    _setup_templates(tmp_path)
+    cfg = AgentConfig(
+        paths=PathsConfig(templates_dir=str(tmp_path)),
+        window=WindowConfig(title_substr="dummy"),
+        channel=ChannelConfig(hotkeys={1: "f7", 2: "f8"}),
+    )
+    keys = KH()
+    cs = channel.ChannelSwitcher(
+        WindowCapture(), cfg.paths.templates_dir, dry=False, keys=keys, hotkeys=cfg.channel.hotkeys
+    )
+    assert cs.switch(1, post_wait=0) is True
+    assert cs.switch(2, post_wait=0) is True
+    assert keys.calls == [(["f7"], 0.05), (["f8"], 0.05)]


### PR DESCRIPTION
## Summary
- extend `ChannelConfig` with configurable hotkeys and expose defaults
- wire GUI config loading/saving to use `ChannelConfig.hotkeys`
- document default channel hotkeys in `agent.yaml`
- add unit test validating channel switching uses configured hotkeys

## Testing
- `pytest tests/test_channel_config.py tests/test_channel_switcher.py::test_custom_hotkeys_respected tests/test_channel_switcher.py::test_default_hotkeys_mapping -q`
- `pytest tests/test_gui_config.py::test_auto_loot_binding tests/test_gui_config.py::test_buff_validation -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7ffa21a2c8330bb5ef5c87d08c88b