### PR TITLE
Pin numpy version compatible with torch and opencv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==2.2.2
+numpy==2.2.1
 opencv-python==4.12.0.88
 pyautogui==0.9.54
 PySide6==6.9.1


### PR DESCRIPTION
## Summary
- pin numpy 2.2.1 per opencv torch compatibility

## Testing
- `python -m venv .venv --system-site-packages`
- `pip install -r requirements.txt --progress-bar off`
- `python -c "import numpy, torch, cv2"`


------
https://chatgpt.com/codex/tasks/task_e_68c7ffa2e93883308ecddf2d829a136d