### PR TITLE
feat: add wmctrl fallback for X11 window capture

### DIFF
--- a/recorder/window_capture/window_capture_x11.py
+++ b/recorder/window_capture/window_capture_x11.py
@@ -1,9 +1,62 @@
 from __future__ import annotations
 
+import subprocess
 import time
+import types
 
 import mss
-import pygetwindow as gw
+try:  # pragma: no cover - pygetwindow unsupported on Linux
+    import pygetwindow as gw
+except Exception:  # ImportError or NotImplementedError
+    gw = types.SimpleNamespace(
+        getAllWindows=lambda: (_ for _ in ()).throw(NotImplementedError)
+    )
+
+
+def _wmctrl_windows() -> list[types.SimpleNamespace]:
+    """Return a list of window-like objects using the ``wmctrl`` command.
+
+    The returned objects mimic the subset of the ``pygetwindow.Window`` API used
+    by :class:`WindowCapture` (``title``, ``left``, ``top``, ``width``,
+    ``height``, ``restore`` and ``activate`` methods).
+    """
+
+    try:
+        out = subprocess.run(
+            ["wmctrl", "-lpG"], capture_output=True, text=True, check=True
+        ).stdout.splitlines()
+    except Exception:
+        return []
+
+    wins: list[types.SimpleNamespace] = []
+    for line in out:
+        parts = line.split(None, 7)
+        if len(parts) < 8:
+            continue
+        wid, _desk, _pid, x, y, w, h, title = parts
+
+        def _activate(win_id=wid):
+            try:
+                subprocess.run(
+                    ["wmctrl", "-i", "-a", win_id], capture_output=True
+                )
+            except Exception:
+                pass
+
+        wins.append(
+            types.SimpleNamespace(
+                wid=wid,
+                title=title.strip(),
+                left=int(x),
+                top=int(y),
+                width=int(w),
+                height=int(h),
+                isMinimized=False,
+                restore=lambda: None,
+                activate=_activate,
+            )
+        )
+    return wins
 
 
 class WindowCapture:
@@ -50,7 +103,15 @@ class WindowCapture:
         attempts = 0
         while True:
             attempts += 1
-            wins = [w for w in gw.getAllWindows() if needle in (w.title or "").lower()]
+            wins: list[types.SimpleNamespace]
+            try:
+                wins = [
+                    w for w in gw.getAllWindows() if needle in (w.title or "").lower()
+                ]
+            except Exception:
+                wins = [
+                    w for w in _wmctrl_windows() if needle in (w.title or "").lower()
+                ]
             if wins:
                 w = wins[0]
                 try:
@@ -73,6 +134,13 @@ class WindowCapture:
             time.sleep(0.05)
         except Exception:
             pass
+        if hasattr(self.win, "wid"):
+            # Refresh geometry for wmctrl fallback windows
+            for w in _wmctrl_windows():
+                if w.wid == self.win.wid:
+                    self.win.left, self.win.top = w.left, w.top
+                    self.win.width, self.win.height = w.width, w.height
+                    break
         left, top = int(self.win.left), int(self.win.top)
         width, height = int(self.win.width), int(self.win.height)
         if width <= 0 or height <= 0:

--- a/tests/test_window_capture.py
+++ b/tests/test_window_capture.py
@@ -63,3 +63,31 @@ def test_locate_returns_false_when_window_missing(monkeypatch):
     wc = _import_wc(monkeypatch, "linux")
     cap = wc.WindowCapture("does-not-exist", poll_sec=0)
     assert cap.locate(timeout=0.01) is False
+
+
+def test_locate_fallbacks_to_wmctrl(monkeypatch):
+    """When ``pygetwindow`` is unusable, ``wmctrl`` fallback should be used."""
+
+    wc = _import_wc(monkeypatch, "linux")
+    impl = importlib.import_module(wc.WindowCapture.__module__)
+
+    def _raise():
+        raise NotImplementedError
+
+    monkeypatch.setattr(impl.gw, "getAllWindows", _raise)
+
+    fake = types.SimpleNamespace(
+        wid="0x1",
+        title="metin2",
+        left=0,
+        top=0,
+        width=100,
+        height=100,
+        isMinimized=False,
+        restore=lambda: None,
+        activate=lambda: None,
+    )
+    monkeypatch.setattr(impl, "_wmctrl_windows", lambda: [fake])
+
+    cap = wc.WindowCapture("metin2", poll_sec=0)
+    assert cap.locate(timeout=0.01) is True


### PR DESCRIPTION
## Summary
- avoid Linux import error by guarding pygetwindow import
- add wmctrl-based window enumeration when pygetwindow is unavailable
- test wmctrl fallback in window capture

## Testing
- `pytest tests/test_window_capture.py -q`
- `pytest -q` *(fails: libGL.so.1 missing)*
- `python - <<'PY'\nfrom agent.infer_wasd import WasdVisionAgent\nfrom agent import get_config\ncfg = get_config()\nWasdVisionAgent(cfg).run()\nPY` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_68c80736d75c83309a634cc382c78a49