### PR TITLE
fix: pin numpy to 1.26 for binary compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = ["assets/**"]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
-numpy = "2.2.2"
+numpy = "1.26.4"
 opencv-python = "4.12.0.88"
 pyautogui = "0.9.54"
 PySide6 = "6.9.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==2.2.1
+numpy==1.26.4
 opencv-python==4.12.0.88
 pyautogui==0.9.54
 PySide6==6.9.1


### PR DESCRIPTION
## Summary
- pin numpy to 1.26 to avoid binary incompatibility errors during agent startup

## Testing
- `python -m pytest tests/test_utils_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c810b643888330956f364c6ad9ffcd