### PR TITLE
Remove unused numpy import from infer_wasd

### DIFF
--- a/agent/infer_wasd.py
+++ b/agent/infer_wasd.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import time
 
-import numpy as np
-
 from recorder.window_capture import WindowCapture
 
 from . import AgentConfig, TeleportSlot


### PR DESCRIPTION
## Summary
- remove the unused numpy import from the vision agent implementation

## Testing
- pyflakes agent/infer_wasd.py

------
https://chatgpt.com/codex/tasks/task_e_68c840451fbc83309d739f8bbccd23f2