### PR TITLE
Remove unused typing import in vision helper

### DIFF
--- a/agent/vision.py
+++ b/agent/vision.py
@@ -9,8 +9,6 @@ minimal so that unit tests can construct frames on the fly without relying on
 external assets.
 """
 
-from typing import Iterable
-
 import numpy as np
 
 # Simple 3x3 binary templates.  Values are either 0 or 255 which makes them


### PR DESCRIPTION
## Summary
- remove the unused typing import from the agent vision helper module

## Testing
- pyflakes agent/vision.py

------
https://chatgpt.com/codex/tasks/task_e_68c84045dcd08330968955a678fe1913