### PR TITLE
Remove unused import from build_gui

### DIFF
--- a/tools/build_gui.py
+++ b/tools/build_gui.py
@@ -12,7 +12,6 @@ The resulting files are placed under the ``dist/`` directory.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 try:


### PR DESCRIPTION
## Summary
- remove unused sys import from tools/build_gui.py

## Testing
- pyflakes tools/build_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68c84046f9b883309111a085ccc27e54