### PR TITLE
Remove unused numpy import from label assistant

### DIFF
--- a/tools/label_assistant.py
+++ b/tools/label_assistant.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Iterable, List, Tuple
 
 import cv2
-import numpy as np
 from ultralytics import YOLO
 from utils.logging_config import logger
 


### PR DESCRIPTION
## Summary
- remove the unused numpy import from `tools/label_assistant.py`

## Testing
- `pyflakes tools/label_assistant.py` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84047dff48330ad7094bdf5f95fc5