### PR TITLE
Remove unused torchvision stub import

### DIFF
--- a/torchvision_stub/__init__.py
+++ b/torchvision_stub/__init__.py
@@ -1,1 +1,0 @@
-from . import models


### PR DESCRIPTION
## Summary
- remove the eager import of torchvision stub models module to leave the namespace empty

## Testing
- pyflakes torchvision_stub/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68c840486bb4833096d0ab475a68b9b1