### PR TITLE
Remove SummaryWriter import from RL training script

### DIFF
--- a/training/train_rl_agent.py
+++ b/training/train_rl_agent.py
@@ -118,8 +118,6 @@ def main() -> None:
 
         if not hasattr(torch, "utils"):
             raise ImportError
-        from torch.utils.tensorboard import SummaryWriter  # type: ignore  # noqa: F401
-
         tb_available = shutil.which("tensorboard") is not None
     except Exception:  # pragma: no cover - allow running without tensorboard
         logging.warning("TensorBoard is not installed; proceeding without logging.")


### PR DESCRIPTION
## Summary
- remove the optional SummaryWriter import from the RL training script since it is unused

## Testing
- pyflakes training/train_rl_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68c84049242883308bfb5bf4bfb281c0