### PR TITLE
Remove unused pytest/importlib imports from test suite

### DIFF
--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -2,8 +2,6 @@ import os
 import sys
 import types
 
-import pytest
-
 # Ensure repository root is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_channel_config.py
+++ b/tests/test_channel_config.py
@@ -4,8 +4,6 @@ import types
 from dataclasses import dataclass
 from typing import Tuple
 
-import pytest
-
 # Ensure repository root on path and stub optional dependencies
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_dungeon_polana.py
+++ b/tests/test_dungeon_polana.py
@@ -1,9 +1,6 @@
-import importlib
 import os
 import sys
 import types
-
-import pytest
 
 # Ensure repository root importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_hunt_destroy.py
+++ b/tests/test_hunt_destroy.py
@@ -1,16 +1,13 @@
-import importlib
 import os
 import sys
 import types
-
-import pytest
 
 # Make repository root importable and stub optional heavy dependencies.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.modules.setdefault("yaml", types.ModuleType("yaml"))
 
 sys.modules.pop("numpy", None)
-np = importlib.import_module("numpy")
+np = __import__("numpy")
 
 cv2_stub = types.ModuleType("cv2")
 cv2_stub.setNumThreads = lambda n: None

--- a/tests/test_label_assistant_cli.py
+++ b/tests/test_label_assistant_cli.py
@@ -1,7 +1,6 @@
 import sys
 import types
 
-import pytest
 from utils.logging_config import logger
 
 
@@ -35,11 +34,9 @@ def test_skip_existing(monkeypatch, tmp_path, caplog):
         ],
     )
 
-    import importlib
-
     handler_id = logger.add(caplog.handler, format="{message}", level="INFO")
-    la = importlib.import_module("tools.label_assistant")
-    la.main()
+    label_assistant = __import__("tools.label_assistant", fromlist=["main"])
+    label_assistant.main()
     logger.remove(handler_id)
 
     assert lbl.read_text() == "orig"

--- a/tests/test_stuck_recovery.py
+++ b/tests/test_stuck_recovery.py
@@ -1,9 +1,7 @@
 import os
 import sys
 import types
-import importlib
 import numpy as np
-import pytest
 
 # Ensure repository root is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_vision_recovery.py
+++ b/tests/test_vision_recovery.py
@@ -1,9 +1,6 @@
-import importlib
 import os
 import sys
 import types
-
-import pytest
 
 # Make repository root importable and stub heavy optional dependencies
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))


### PR DESCRIPTION
## Summary
- drop unused pytest imports from several test modules to avoid redundant dependencies
- replace importlib usage with built-in module loading helpers where necessary

## Testing
- pyflakes tests/test_agent_config.py
- pyflakes tests/test_channel_config.py
- pyflakes tests/test_dungeon_polana.py
- pyflakes tests/test_hunt_destroy.py
- pyflakes tests/test_label_assistant_cli.py
- pyflakes tests/test_stuck_recovery.py
- pyflakes tests/test_vision_recovery.py

------
https://chatgpt.com/codex/tasks/task_e_68c8404a55a88330942eaca0d777860c