### PR TITLE
Remove unused QApplication variable from agent panel test

### DIFF
--- a/tests/test_agent_panel.py
+++ b/tests/test_agent_panel.py
@@ -10,7 +10,7 @@ from gui.widgets.agent_panel import AgentPanel
 
 
 def test_get_config_autopress():
-    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
     panel = AgentPanel()
     panel.auto_press_chk.setChecked(True)
     panel.auto_press_key.setText("x")


### PR DESCRIPTION
## Summary
- remove the unused QApplication assignment in the agent panel test to satisfy linting

## Testing
- pyflakes tests/test_agent_panel.py

------
https://chatgpt.com/codex/tasks/task_e_68c8404a77308330a2d8829f731e2923