### PR TITLE
Add cv2 thread configuration support

### DIFF
--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -74,7 +74,7 @@ class HuntDestroy(AgentStrategy):
             cfg.detector.classes,
             cfg.detector.conf_thr,
             cfg.detector.iou_thr,
-            cv2_threads=getattr(cfg.detector, "cv2_threads", 0),
+            cv2_threads=cfg.detector.cv2_threads,
         )
         self.avoid = CollisionAvoid()
         dry = cfg.dry_run

--- a/config/models.py
+++ b/config/models.py
@@ -50,6 +50,7 @@ class DetectorConfig(BaseModel):
     conf_thr: float = 0.5
     iou_thr: float = 0.45
     policy: DetectorPolicy = DetectorPolicy()
+    cv2_threads: int | None = None
 
 
 class StuckConfig(BaseModel):


### PR DESCRIPTION
## Summary
- add a cv2_threads option to DetectorConfig so detectors can configure OpenCV threading
- use the new configuration field when building the HuntDestroy detector

## Testing
- pytest tests/test_detector.py

------
https://chatgpt.com/codex/tasks/task_e_68c8441a639883309c2a43a51f73ca8a