### PR TITLE
Handle optional detector thread configuration

### DIFF
--- a/agent/cycle.py
+++ b/agent/cycle.py
@@ -55,7 +55,9 @@ class CycleFarm:
         )
         self.agent: AgentStrategy = load_strategy(cfg, self.win)
         self.det = ObjectDetector(
-            cfg.paths.model, cfg.detector.classes, cv2_threads=cfg.detector.cv2_threads
+            cfg.paths.model,
+            cfg.detector.classes,
+            cv2_threads=getattr(cfg.detector, "cv2_threads", None),
         )
         self._stop = False
 

--- a/agent/dungeon_polana.py
+++ b/agent/dungeon_polana.py
@@ -58,7 +58,7 @@ class DungeonPolana(AgentStrategy):
             cfg.detector.classes,
             cfg.detector.conf_thr,
             cfg.detector.iou_thr,
-            cv2_threads=cfg.detector.cv2_threads,
+            cv2_threads=getattr(cfg.detector, "cv2_threads", None),
         )
         dry = cfg.dry_run
         self.keys = KeyHold(dry=dry, active_fn=getattr(self.win, "is_foreground", None))

--- a/agent/hunt_destroy.py
+++ b/agent/hunt_destroy.py
@@ -74,7 +74,7 @@ class HuntDestroy(AgentStrategy):
             cfg.detector.classes,
             cfg.detector.conf_thr,
             cfg.detector.iou_thr,
-            cv2_threads=cfg.detector.cv2_threads,
+            cv2_threads=getattr(cfg.detector, "cv2_threads", None),
         )
         self.avoid = CollisionAvoid()
         dry = cfg.dry_run

--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -22,6 +22,7 @@ detector:
   classes: ["metin","boss","potwory"]
   conf_thr: 0.5
   iou_thr: 0.45
+  cv2_threads: null  # Set to an integer to override OpenCV's default thread count
   policy:
     deadzone_x: 0.05
     desired_box_w: 0.12


### PR DESCRIPTION
## Summary
- guard ObjectDetector construction against missing `cv2_threads`
- document the optional `cv2_threads` setting in the agent configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c845d098e483309fa072cdef8c4962