### PR TITLE
Add scan config defaults and align UI

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -11,6 +11,9 @@ try:  # yaml is optional for tests
     import yaml
 except Exception:  # pragma: no cover - provide dummy fallback
     yaml = types.SimpleNamespace(safe_load=lambda f: {})
+else:  # pragma: no cover - provide dummy fallback when incomplete
+    if not hasattr(yaml, "safe_load"):
+        yaml = types.SimpleNamespace(safe_load=lambda f: {})
 
 _cfg: AgentConfig | None = None
 

--- a/config/models.py
+++ b/config/models.py
@@ -60,10 +60,13 @@ class StuckConfig(BaseModel):
 
 
 class ScanConfig(BaseModel):
+    enabled: bool = True
     period: float = 0.066
     key: str = "e"
     sweeps: int = 8
     sweep_ms: int = 250
+    idle_sec: float = 0.0
+    pause: float = 0.0
 
 
 class CooldownsConfig(BaseModel):

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1153,7 +1153,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.rotate_chk.setChecked(bool(scan.get("enabled", True)))
         self.sweeps.setValue(int(scan.get("sweeps", 8)))
         self.sweep_ms.setValue(int(scan.get("sweep_ms", 250)))
-        self.idle_sec.setValue(float(scan.get("idle_sec", 1.5)))
+        self.idle_sec.setValue(float(scan.get("idle_sec", 0.0)))
         self.cooldown_spin.setValue(int(cfg.get("cooldowns", {}).get("slot_min", 10)))
         self.templates_dir_edit.setText(paths.get("templates_dir", "assets/templates"))
         ui = cfg.get("ui", {})

--- a/gui/widgets/scan_panel.py
+++ b/gui/widgets/scan_panel.py
@@ -23,9 +23,9 @@ class ScanPanel(QtWidgets.QGroupBox):
         form.addRow(self.sweep_ms_label, self.sweep_ms)
 
         self.idle_sec = QtWidgets.QDoubleSpinBox()
-        self.idle_sec.setRange(0.5, 5.0)
+        self.idle_sec.setRange(0.0, 5.0)
         self.idle_sec.setSingleStep(0.1)
-        self.idle_sec.setValue(1.5)
+        self.idle_sec.setValue(0.0)
         self.idle_sec_label = QtWidgets.QLabel()
         form.addRow(self.idle_sec_label, self.idle_sec)
 
@@ -57,6 +57,6 @@ class ScanPanel(QtWidgets.QGroupBox):
                 "sweep_ms": int(self.sweep_ms.value()),
                 "idle_sec": float(self.idle_sec.value()),
                 "period": 0.066,
-                "pause": 0.12,
+                "pause": 0.0,
             }
         }


### PR DESCRIPTION
## Summary
- add enabled, idle_sec, and pause defaults to ScanConfig to match config/agent.yaml
- align scan panel defaults and config loading with the new scan settings
- harden YAML loader fallback when safe_load is unavailable

## Testing
- pytest tests/test_hunt_destroy.py

------
https://chatgpt.com/codex/tasks/task_e_68c84eaabc248330b488ab2afbf45c1c