### PR TITLE
Add cooldown slot minimum configuration

### DIFF
--- a/config/agent.yaml
+++ b/config/agent.yaml
@@ -42,7 +42,7 @@ scan:
   pause: 0.0
 
 cooldowns:
-  attack: 0.0
+  slot_min: 10
 
 auto_press:
   enabled: false

--- a/config/models.py
+++ b/config/models.py
@@ -70,7 +70,7 @@ class ScanConfig(BaseModel):
 
 
 class CooldownsConfig(BaseModel):
-    pass
+    slot_min: int = 10
 
 
 class AutoPressConfig(BaseModel):


### PR DESCRIPTION
## Summary
- add a default `slot_min` field to `CooldownsConfig` so cycle farm can read the cooldown threshold
- expose the same `slot_min` default in `config/agent.yaml` to replace the unused `attack` setting

## Testing
- pytest tests/test_cycle_sequence.py

------
https://chatgpt.com/codex/tasks/task_e_68c8603b06a08330bf88b5fff3eca3dd